### PR TITLE
add graphics.Dimension to legacy.ENTITY_WRAPPERS

### DIFF
--- a/ezdxf/legacy/__init__.py
+++ b/ezdxf/legacy/__init__.py
@@ -98,6 +98,7 @@ ENTITY_WRAPPERS = {
     'POLYLINE': graphics.Polyline,
     'VERTEX': graphics.Vertex,
     'SEQEND': graphics.SeqEnd,
+    'DIMENSION': graphics.Dimension,
     'SHAPE': graphics.Shape,
     'VIEWPORT': Viewport,
 }


### PR DESCRIPTION
The legacy factory returns DEFAULT_WRAPPER for DIMENSION entity. Proper wrapper class is graphics.Dimension.