### PR TITLE
Added missing ezdxf.audit line to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
               'ezdxf.sections',
               'ezdxf.templates',
               'ezdxf.tools',
+              'ezdxf.audit',
               ],
     package_data={'ezdxf': ['templates/*.dxf',
                             'pp/dxfpp.html',


### PR DESCRIPTION
I was just about to prepare a package for [conda-forge](https://conda-forge.org/) (would you be interested to be added as maintainer?) as I spotted that the `dxfaudit` is currently not working, as `ezdxf.audit` is not added to the package files (it is missing from the PyPI source distribution as well).