### PR TITLE
Misc. typo fixes

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -16,7 +16,7 @@ Version 0.8.9 - dev
       arrays; Spline.get_knot_values(), Spline.get_weights(), Spline.get_control_points() and Spline.get_fit_points()
       are deprecated, direct access to this attributes by Spline.knot_values, Spline.weights, Spline.control_points and
       Spline.fit_points all with a list-like interface. Knot, control point and fit point counter updated automatically,
-      therefor counters are read only now.
+      therefore counters are read only now.
     - NEW: packed data for MESH, vertices, faces, edges and edge crease values stored as array.array(), high level interface unchanged
     - NEW: Drawing.layouts_and_blocks(), iterate over all layouts (mode space and paper space) and all block definitions.
     - NEW: Drawing.chain_layouts_and_blocks(), chain entity spaces of all layouts and blocks. Yields an iterator for all
@@ -350,7 +350,7 @@ Version 0.6.0 - 2014-04-25
   * Supported Python versions: CPython 2.7, 3.4 and pypy 2.2.1
   * Refactoring of internal structures
   * CHANGE: appended entities like VERTEX for POLYLINE and ATTRIB for INSERT are linked to the main entity and do
-    not appear in layouts, model space or blocks (modelspace.query('VERTEX') is always an emtpy list).
+    not appear in layouts, model space or blocks (modelspace.query('VERTEX') is always an empty list).
   * CHANGE: refactoring of the internal 2D/3D point representation for reduced memory footprint
   * faster unittests
   * BUGFIX: opens minimalistic DXF12 files

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Abstract
 --------
 
 A Python package to create and modify DXF drawings, independent from the DXF
-version. You can open/save every DXF file without loosing any content (except comments),
+version. You can open/save every DXF file without losing any content (except comments),
 Unknown tags in the DXF file will be ignored but preserved for saving. With this behavior
 it is possible to open also DXF drawings that contains data from 3rd party applications.
 

--- a/docs/notes/dimvars.txt
+++ b/docs/notes/dimvars.txt
@@ -1,4 +1,4 @@
-AutoCAD Dimension Variabes
+AutoCAD Dimension Variables
 ==========================
 
 DIMADEC                         Controls the number of decimal places for angular dimensions.

--- a/docs/source/addons/curves.rst
+++ b/docs/source/addons/curves.rst
@@ -12,7 +12,7 @@ placing.
 .. method:: Spline.__init__(points=None, segments=100)
 
     :param points: spline definition points
-    :param segemnts: count of line segemnts for approximation, vertex count is segments+1
+    :param segments: count of line segments for approximation, vertex count is segments+1
 
 .. method:: Spline.render_as_fit_points(layout, degree=3, method='distance', power=.5, dxfattribs=None)
 

--- a/docs/source/algebra/vector.rst
+++ b/docs/source/algebra/vector.rst
@@ -44,7 +44,7 @@ Vector
         Vector(3, 6, 9) / 3 == Vector(1, 2, 3)
         -Vector(1, 2, 3) == (-1, -2, -3)
 
-    Comparision between vectors and vectors to tuples is supported::
+    Comparison between vectors and vectors to tuples is supported::
 
         Vector(1, 2, 3) < Vector (2, 2, 2)
         (1, 2, 3) < tuple(Vector(2, 2, 2))  # conversion necessary

--- a/docs/source/dxfinternals/block_management.rst
+++ b/docs/source/dxfinternals/block_management.rst
@@ -15,7 +15,7 @@ The :code:`(10, base_point)` tag (in BLOCK defines a insertion point of the bloc
 the INSERT entity, this point of the block is placed at the location defined by the :code:`(10, insert)` tag in
 the INSERT entity, and it is also the base point for stretching and rotation.
 
-A block defintion can contain INSERT entities, and it is possible to create cyclic block definitions (a
+A block definition can contain INSERT entities, and it is possible to create cyclic block definitions (a
 BLOCK contains a INSERT of itself), but this should be avoided, CAD applications will not load the DXF file at all or
 maybe just crash. This is also the case for all other kinds of cyclic definitions like: BLOCK 'A' -> INSERT BLOCK 'B'
 and BLOCK 'B' -> INSERT BLOCK 'A'.
@@ -248,7 +248,7 @@ DXF R13 BLOCK_RECORD structure:
     4
     0           <<< start of first BLOCK_RECORD entry
     BLOCK_RECORD
-    5           <<< handle of BLOCK_RECORD, in ezdxf often refered as 'layout key'
+    5           <<< handle of BLOCK_RECORD, in ezdxf often referred to as 'layout key'
     1F
     330         <<< owner of the BLOCK_RECORD is the BLOCK_RECORD table
     1
@@ -271,7 +271,7 @@ DXF R13 BLOCK_RECORD structure:
     ...
     0           <<< next BLOCK_RECORD
     BLOCK_RECORD
-    5           <<< handle of BLOCK_RECORD, in ezdxf often refered as 'layout key'
+    5           <<< handle of BLOCK_RECORD, in ezdxf often referred to as 'layout key'
     238
     330         <<< owner of the BLOCK_RECORD is the BLOCK_RECORD table
     1

--- a/docs/source/dxfinternals/classes_section.rst
+++ b/docs/source/dxfinternals/classes_section.rst
@@ -23,7 +23,7 @@ CLASS Entities
 
     DXF Reference: `Group Codes for the CLASS entity`_
 
-CLASS entities have no handle and therefor ezdxf does not store the CLASS entity in the drawing entities database!
+CLASS entities have no handle and therefore ezdxf does not store the CLASS entity in the drawing entities database!
 
 .. code-block:: none
 

--- a/docs/source/dxfinternals/coordinate_systems.rst
+++ b/docs/source/dxfinternals/coordinate_systems.rst
@@ -25,7 +25,7 @@ User coordinate system - the working coordinate system defined by the user to ma
 passed to AutoCAD commands, including those returned from AutoLISP routines and external functions, are points in the
 current UCS. As far as I know, all coordinates stored in DXF files are always WCS or OCS never UCS.
 
-User defined coordinate systems are not just helpful for interactive CAD, therefor ezdxf provides a converter class
+User defined coordinate systems are not just helpful for interactive CAD, therefore ezdxf provides a converter class
 :class:`~ezdxf.algebra.UCS` to translate coordinates from UCS into WCS and vice versa, but always remember: store only
 WCS or OCS coordinates in DXF files, because there is no method to determine which UCS was active or used to create UCS
 coordinates.

--- a/docs/source/dxfinternals/layout_management.rst
+++ b/docs/source/dxfinternals/layout_management.rst
@@ -198,7 +198,7 @@ Main VIEWPORT Entity for LAYOUT
 
 The "main" viewport for layout ``Layout1`` shown above. This viewport is located in the associated BLOCK definition called
 ``*Paper_Space0``. Group code 330 in subclass AcDbLayout points to the BLOCK_RECORD of ``*Paper_Space0``.
-Remember: the entities of the `active` paper space layout are located in the ENTITIES section, therefor ``Layout1`` is not
+Remember: the entities of the `active` paper space layout are located in the ENTITIES section, therefore ``Layout1`` is not
 the active paper space layout.
 
 The "main" VIEWPORT describes, how the application shows the paper space layout on the screen, and I guess only AutoCAD

--- a/docs/source/layouts.rst
+++ b/docs/source/layouts.rst
@@ -228,7 +228,7 @@ Create New Entities
 .. method:: Layout.add_rational_spline(control_points, weights, degree=3, dxfattribs=None)
 
    Add an open rational uniform :class:`Spline`, `control_points` has to be a list (container or generator) of (x, y, z)
-   tuples, `weights` has to be a list of values, which defines the influence of the associated control point, therefor
+   tuples, `weights` has to be a list of values, which defines the influence of the associated control point, therefore
    count of control points has to be equal to the count of weights, `degree` specifies degree of spline. (requires DXF
    version AC1015 or later)
 
@@ -238,7 +238,7 @@ Create New Entities
 .. method:: Layout.add_closed_rational_spline(control_points, weights, degree=3, dxfattribs=None)
 
    Add a closed rational uniform :class:`Spline`, `control_points` has to be a list (container or generator) of (x, y, z)
-   tuples, `weights` has to be a list of values, which defines the influence of the associated control point, therefor
+   tuples, `weights` has to be a list of values, which defines the influence of the associated control point, therefore
    count of control points has to be equal to the count of weights, `degree` specifies degree of spline. (requires DXF
    version AC1015 or later)
 

--- a/docs/source/r12writer.rst
+++ b/docs/source/r12writer.rst
@@ -161,7 +161,7 @@ Reference
 
 .. method:: R12FastStreamWriter.add_3dface(vertices, invisible=0, layer="0", color=None, linetype=None)
 
-    Add a 3DFACE entity. 3DFACE is a spatial area with 3 ot 4 vertices, all vertices have to be in the same plane.
+    Add a 3DFACE entity. 3DFACE is a spatial area with 3 or 4 vertices, all vertices have to be in the same plane.
 
     :param vertices: list of 3 or 4 (x, y, z) vertices.
     :param invisible: bit coded flag to define the invisible edges, 1. edge = 1, 2. edge = 2, 3. edge = 4, 4. edge = 8;

--- a/docs/source/tutorials/layers.rst
+++ b/docs/source/tutorials/layers.rst
@@ -26,7 +26,7 @@ Create a new layer definition::
     dwg.layers.new(name='MyLines', dxfattribs={'linetype': 'DASHED', 'color': 7})
 
 The advantage of assigning a linetype and a color to a layer is that entities on this layer can inherit this properties
-by using ``BYLAYER`` as linetype string ans `256` as color, both values are default values for new entities so you can
+by using ``BYLAYER`` as linetype string and `256` as color, both values are default values for new entities so you can
 left off this assignments::
 
     msp.add_line((0, 0), (10, 0), dxfattribs={'layer': 'Lines'})

--- a/examples/addons/using_table_addon.py
+++ b/examples/addons/using_table_addon.py
@@ -54,7 +54,7 @@ table.new_cell_style(
     rotation=90,  # vertical written
     bgcolor=8,
 )
-# set colum width, first column has index 0
+# set column width, first column has index 0
 table.set_col_width(1, 7)
 
 # set row height, first row has index 0

--- a/examples/tut/spline/modified_spline.py
+++ b/examples/tut/spline/modified_spline.py
@@ -4,7 +4,7 @@ dwg = ezdxf.readfile("AutoCAD_generated.dxf")
 
 msp = dwg.modelspace()
 spline = msp.query('SPLINE')[0]  # take the first spline
-with spline.edit_data() as data:  # context manger
+with spline.edit_data() as data:  # context manager
     data.fit_points.append((2250, 2500, 0))  # data.fit_points is a standard python list
 
     # As far as I tested this works without complaints from AutoCAD, but for the case of problems

--- a/ezdxf/acadctb.py
+++ b/ezdxf/acadctb.py
@@ -444,7 +444,7 @@ class CtbParser(object):
     """
 
     def __init__(self, text):
-        """Construtor
+        """Constructor
 
         text -- ctb content as string
         """

--- a/ezdxf/addons/sierpinski_pyramid.py
+++ b/ezdxf/addons/sierpinski_pyramid.py
@@ -136,7 +136,7 @@ def sierpinsky_pyramid(location=(0., 0., 0.), length=1., level=1, sides=4):
     Args:
         location: base center point of the pyramid
         length: base length of the pyramid
-        level: recursive building levels, has to 1 ot bigger
+        level: recursive building levels, has to 1 or bigger
         sides: 3 or 4 sided pyramids supported
 
     Returns: list of pyramid vertices

--- a/ezdxf/addons/table.py
+++ b/ezdxf/addons/table.py
@@ -153,7 +153,7 @@ class Table(object):
         try:
             return self._cells[row, col]
         except KeyError:
-            return self.empty_cell  # emtpy cell with default style
+            return self.empty_cell  # empty cell with default style
 
     def validate_index(self, row, col):
         row = int(row)
@@ -406,7 +406,7 @@ class Grid(object):
         self.col_pos = self._calc_col_pos()
         # contains the y-axis coords of the grid lines between the data rows.
         self.row_pos = self._calc_row_pos()
-        # contans the horizontal border elements, list of border styles
+        # contains the horizontal border elements, list of border styles
         # get index with _border_index(row, col), which means the border element
         # above row, col, and row-indices are [0 .. nrows+1], nrows+1 for the
         # grid line below the last row; list contains only the border style with

--- a/ezdxf/algebra/bspline.py
+++ b/ezdxf/algebra/bspline.py
@@ -308,7 +308,7 @@ def bspline_basis(u, index, degree, knots):
     """
     B-spline basis function.
 
-    Simple recursive implementation for testing and comparision.
+    Simple recursive implementation for testing and comparison.
 
     Args:
         u: curve parameter in range [0 .. max(knots)]
@@ -346,7 +346,7 @@ def bspline_basis_vector(u, count, degree, knots):
     """
     Create basis vector at parameter u.
 
-    Used with the bspline_basis() for testing and comparision.
+    Used with the bspline_basis() for testing and comparison.
 
     Args:
         u: curve parameter in range [0 .. max(knots)]
@@ -368,7 +368,7 @@ def bspline_vertex(u, degree, control_points, knots):
     """
     Calculate B-spline vertex at parameter u.
 
-    Used with the bspline_basis_vector() for testing and comparision.
+    Used with the bspline_basis_vector() for testing and comparison.
 
     Args:
         u:  curve parameter in range [0 .. max(knots)]

--- a/ezdxf/graphicsfactory.py
+++ b/ezdxf/graphicsfactory.py
@@ -229,7 +229,7 @@ class GraphicsFactory(object):
     def add_spline(self, fit_points=None, degree=3, dxfattribs=None):
         """
         Add a B-spline defined by fit points, the control points and knot values are created by the CAD application,
-        therefor it is not predictable how the rendered spline will look like, because for every set of fit points
+        therefore it is not predictable how the rendered spline will look like, because for every set of fit points
         exists an infinite set of B-splines. If fit_points is None, an 'empty' spline will be created, all data has to
         be set by the user.
 

--- a/ezdxf/legacy/layouts.py
+++ b/ezdxf/legacy/layouts.py
@@ -417,7 +417,7 @@ class DXF12BlockLayout(BaseLayout):
 
         Args:
             tag (str): attribute name as string without spaces
-            insert: attribute insert point relative to blcok origin (0, 0, 0)
+            insert: attribute insert point relative to block origin (0, 0, 0)
             text (str): preset text for attribute
 
         """

--- a/ezdxf/lldxf/extendedtags.py
+++ b/ezdxf/lldxf/extendedtags.py
@@ -84,7 +84,7 @@ class ExtendedTags(object):
             # EXCEPT DIMASSOC has one subclass starting with: (1, AcDbOsnapPointRef). Well done, Autodesk!
             # This special subclass is ignored by ezdxf, content is included in the preceding subclass: (100, AcDbDimAssoc)
             #
-            # TEXT contains 2x the (100, AcDbText). Also well done, Autodesk! Therefor it is not possible to use an
+            # TEXT contains 2x the (100, AcDbText). Also well done, Autodesk! Therefore it is not possible to use an
             # (ordered) dict where subclass name is key, but usual use case is access by index.
 
             data = Tags() if starttag is None else Tags([starttag])
@@ -359,7 +359,7 @@ def get_xtags_linker():
                 #   ATTRIB as connected entity
                 #   SEQEND
                 #
-                # Therefor a ATTRIB following an INSERT doesn't mean that these entities are connected.
+                # Therefore a ATTRIB following an INSERT doesn't mean that these entities are connected.
                 pass
             else:
                 vars.prev = tags

--- a/ezdxf/modern/groups.py
+++ b/ezdxf/modern/groups.py
@@ -188,6 +188,6 @@ class GroupManager(ObjectManager):
                 # do not delete groups while iterating over groups!
                 empty_groups.append(name)
 
-        # now delete emtpy groups
+        # now delete empty groups
         for name in empty_groups:
             self.delete(name)

--- a/ezdxf/modern/mleader.py
+++ b/ezdxf/modern/mleader.py
@@ -8,7 +8,7 @@ from .dxfobjects import DXFObject
 from .object_manager import ObjectManager
 
 # DXF Examples:
-# D:\source\dxftest\CADKitSamples\house design for two family with comman staircasedwg.dxf
+# D:\source\dxftest\CADKitSamples\house design for two family with common staircasedwg.dxf
 # D:\source\dxftest\CADKitSamples\house design.dxf
 
 _MLEADER_CLS = """0

--- a/ezdxf/r12writer.py
+++ b/ezdxf/r12writer.py
@@ -96,7 +96,7 @@ class R12FastStreamWriter(object):
         dxf.append(dxf_attribs(layer, color, linetype))
         vertices = list(vertices)
         if len(vertices) < 3:
-            raise DXFValueError("%s needs 3 ot 4 vertices." % dxftype)
+            raise DXFValueError("%s needs 3 or 4 vertices." % dxftype)
         elif len(vertices) == 3:
             vertices.append(vertices[-1])  # double last vertex
         dxf.extend(dxf_vertex(vertex, code) for code, vertex in enumerate(vertices, start=10))

--- a/ezdxf/sections/acdsdata.py
+++ b/ezdxf/sections/acdsdata.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2014, Manfred Moitzi
 # License: MIT License
 """
-ACDSDATA entities have NO handles, therefor they can not be stored in the drawing entity database.
+ACDSDATA entities have NO handles, therefore they can not be stored in the drawing entity database.
 every routine written until now (2014-05-05), expects entities with valid handle
 
 section structure (work in progress):

--- a/ezdxf/tools/complex_ltype.py
+++ b/ezdxf/tools/complex_ltype.py
@@ -1,4 +1,4 @@
-# Purpose: compiler for line type defintions
+# Purpose: compiler for line type definitions
 # Created: 12.01.2018
 # Copyright (C) 2018, Manfred Moitzi
 # License: MIT License

--- a/ezdxf/tools/juliandate.py
+++ b/ezdxf/tools/juliandate.py
@@ -40,7 +40,7 @@ class CalendarDate:
         Z = floor(self.jdate)
 
         if Z < 2299161:
-            A = Z  # julian calender
+            A = Z  # julian calendar
         else:
             g = floor((Z - 1867216.25) / 36524.25)  # gregorian calendar
             A = Z + 1. + g - floor(g / 4.)

--- a/ezdxf/tools/perlin.py
+++ b/ezdxf/tools/perlin.py
@@ -82,7 +82,7 @@ class BaseNoise:
         table with period elements. The period determines the (integer)
         interval that the noise repeats, which is useful for creating tiled
         textures.  period should be a power-of-two, though this is not
-        enforced. Note that the speed of the noise algorithm is indpendent of
+        enforced. Note that the speed of the noise algorithm is independent of
         the period size, though larger periods mean a larger table, which
         consume more memory.
 
@@ -323,7 +323,7 @@ def grad3(hash, x, y, z):
 
 
 class TileableNoise(BaseNoise):
-    """Tileable implemention of Perlin "improved" noise. This
+    """Tileable implementation of Perlin "improved" noise. This
     is based on the reference implementation published here:
 
     http://mrl.nyu.edu/~perlin/noise/

--- a/tests/test_modern_structures/test_geodata.py
+++ b/tests/test_modern_structures/test_geodata.py
@@ -82,7 +82,7 @@ def test_geodata_coordinate_system_definition(geodata):
 
 
 def test_internals_set_geodata_coordinate_system_definition_(geodata):
-    # in this case interal structure testing is required
+    # in this case internal structure testing is required
     geodata.AcDbGeoData.remove_tags((301, 303))  # delete existing text
     assert geodata.get_coordinate_system_definition() == ''
 


### PR DESCRIPTION
Found via `codespell -q 3 -I ../ezdxf-word-whitelist.txt` where the whitelist consists of:
```
aci
ang
oder
taget
unter
```