### PR TITLE
"coding: utf-8" magic comments (PEP 263)

### DIFF
--- a/examples/using_groupby.py
+++ b/examples/using_groupby.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Purpose: example for using the groupby feature
 # Created: 03.02.2017
 # Copyright (c) 2017 Manfred Moitzi

--- a/ezdxf/addons/dimlines.py
+++ b/ezdxf/addons/dimlines.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Purpose: dimension lines as composite entities build with basic dxf entities, but not the DIMENSION entity.
 # Created: 10.03.2010, 2018 adapted for ezdxf
 # Copyright (c) 2010-2018, Manfred Moitzi

--- a/ezdxf/legacy/graphics.py
+++ b/ezdxf/legacy/graphics.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Purpose: DXF 12 graphics entities
 # Created: 25.03.2011
 # Copyright (c) 2011-2018, Manfred Moitzi

--- a/ezdxf/modern/dimension.py
+++ b/ezdxf/modern/dimension.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Purpose: support for the Ac1015 DIMENSION entity
 # Created: 09.03.2016
 # Copyright (C) 2016, Manfred Moitzi

--- a/ezdxf/tools/complex_ltype.py
+++ b/ezdxf/tools/complex_ltype.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Purpose: compiler for line type defintions
 # Created: 12.01.2018
 # Copyright (C) 2018, Manfred Moitzi


### PR DESCRIPTION
Some source files have UTF-8 characters. Python 2 fails with `SyntaxError: Non-ASCII character`. Adding magic encoding comments, like suggested by [PEP 263](https://www.python.org/dev/peps/pep-0263/), fixes the problem.