### PR TITLE
Construction Line intersect bug

### DIFF
--- a/ezdxf/math/line.py
+++ b/ezdxf/math/line.py
@@ -116,11 +116,23 @@ class ConstructionRay:
         ray2 = other
         if not ray1.is_parallel(ray2):
             if ray1._is_vertical:
-                x = self._location.x
-                y = ray2.yof(x)
+                x = ray1._location.x
+                if ray2.is_horizontal:
+                    y = ray2._location.y
+                else:
+                    y = ray2.yof(x)
             elif ray2._is_vertical:
                 x = ray2._location.x
-                y = ray1.yof(x)
+                if ray1.is_horizontal:
+                    y = ray1._location.y
+                else:
+                    y = ray1.yof(x)
+            elif ray1.is_horizontal:
+                y = ray1._location.y
+                x = ray2.xof(y)
+            elif ray2.is_horizontal:
+                y = ray2._location.y
+                x = ray1.xof(y)
             else:
                 # calc intersection with the 'straight-line-equation'
                 # based on y(x) = y0 + x*slope

--- a/tests/test_06_math/test_641_construction_ray.py
+++ b/tests/test_06_math/test_641_construction_ray.py
@@ -46,7 +46,27 @@ class TestConstructionRay:
         ray1 = ConstructionRay((10, 1), (10, -7))
         ray2 = ConstructionRay((-10, 3), (17, -7))
         point = ray1.intersect(ray2)
+        assert point.x == 10
         assert point.isclose(Vector(10., -4.4074), abs_tol=1e-4)
+        with pytest.raises(ArithmeticError):
+            _ = ray1.yof(1)
+            
+    def test_ray2d_intersect_with_horizontal(self):
+        ray1 = ConstructionRay((-10, 10), (10, 10))
+        ray2 = ConstructionRay((-10, 20), (10, 0))
+        point = ray1.intersect(ray2)
+        assert point.y == 10
+        assert point.isclose(Vector(0.0, 10.0), abs_tol=1e-4)
+        with pytest.raises(ArithmeticError):
+            _ = ray1.yof(1)
+            
+    def test_ray2d_intersect_with_vertical_and_horizontal(self):
+        ray1 = ConstructionRay((-10, 10), (10, 10))
+        ray2 = ConstructionRay((5, 0), (5, 20))
+        point = ray1.intersect(ray2)
+        assert point.y == 10
+        assert point.x == 5
+        assert point.isclose(Vector(5.0, 10.0), abs_tol=1e-4)
         with pytest.raises(ArithmeticError):
             _ = ray1.yof(1)
 


### PR DESCRIPTION
Sometimes ConstructionLine has_intersect returns false when it should be true.

My construction line is horizontal on the line y=248.725, the point returned by self.ray.intersect has y=248.72500000000002. The point is therefore not in the bounding box and has_intersect returns true.

This change fixes my bug and should cover all edge cases I can think of.