### PR TITLE
Fix wrong reference to the "center_point" attribute

### DIFF
--- a/docs/source/tables/vport_table_entry.rst
+++ b/docs/source/tables/vport_table_entry.rst
@@ -50,7 +50,7 @@ Factory function         :meth:`Drawing.viewports.new`
 
         Upper-right corner of viewport
 
-    .. attribute:: dxf.center_point
+    .. attribute:: dxf.center
 
         View center point (in :ref:`DCS`)
 


### PR DESCRIPTION
"center_point" doesn't exist as dxf attribute of this class anymore and is now accessible as "center" attribute