### PR TITLE
Tolerance too low

### DIFF
--- a/src/ezdxf/math/construct2d.py
+++ b/src/ezdxf/math/construct2d.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 HALF_PI = math.pi / 2.0
 THREE_PI_HALF = 1.5 * math.pi
 DOUBLE_PI = math.pi * 2.0
-TOLERANCE = 1e-12
+TOLERANCE = 1e-11
 
 _90_DEG = math.pi / 2.0
 _180_DEG = math.pi

--- a/src/ezdxf/math/construct2d.py
+++ b/src/ezdxf/math/construct2d.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 HALF_PI = math.pi / 2.0
 THREE_PI_HALF = 1.5 * math.pi
 DOUBLE_PI = math.pi * 2.0
-TOLERANCE = 1e-11
+TOLERANCE = 1e-10
 
 _90_DEG = math.pi / 2.0
 _180_DEG = math.pi


### PR DESCRIPTION
Using ConstructionLine.intersect() I got no intersect where there should be one. 

My error was on the order of 5e-12

Perhaps 1e-10 would be safer though.