### PR TITLE
Query matches unicode string of attribute value

### DIFF
--- a/src/ezdxf/queryparser.py
+++ b/src/ezdxf/queryparser.py
@@ -48,7 +48,9 @@ RBRK = Suppress(']')
 
 number = Regex(r"[+-]?\d+(:?\.\d*)?(:?[eE][+-]?\d+)?")
 number.addParseAction(lambda t: float(t[0]))  # convert to float
-string_ = quotedString.addParseAction(lambda t: t[0][1:-1])  # remove quotes
+qs = QuotedString("'", unquoteResults=True)
+dqs = QuotedString('"', unquoteResults=True)
+string_ = (qs | dqs).setName('quotedString using single or double quotes')
 
 EntityName = Word(alphanums + '_')
 # ExcludeEntityName = Word(alphanums + '_!')


### PR DESCRIPTION
dxf can embed unicode strings in itself.
quotedString only matches ascii strings and that's why this library skips these elements when querying some unicode-string named attributes.