### PR TITLE
Return skipped entities

### DIFF
--- a/src/ezdxf/entities/insert.py
+++ b/src/ezdxf/entities/insert.py
@@ -451,7 +451,7 @@ class Insert(DXFGraphic):
 
     def virtual_entities(self,
                          non_uniform_scaling=False,
-                         skipped_entity_callback: Optional[Callable[['DXFGraphic'], None]] = None
+                         skipped_entity_callback: Optional[Callable[['DXFGraphic', str], None]] = None
                          ) -> Iterable[DXFGraphic]:
         """
         Yields "virtual" entities of a block reference. This method is meant to examine the block reference

--- a/src/ezdxf/entities/insert.py
+++ b/src/ezdxf/entities/insert.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019-2020 Manfred Moitzi
 # License: MIT License
 # Created 2019-02-16
-from typing import TYPE_CHECKING, Iterable, cast, Tuple, Union, Optional, List, Dict
+from typing import TYPE_CHECKING, Iterable, cast, Tuple, Union, Optional, List, Dict, Callable
 import math
 from ezdxf.math import Vector, UCS, BRCS, X_AXIS, Y_AXIS
 from ezdxf.lldxf.attributes import DXFAttr, DXFAttributes, DefSubclass, XType
@@ -449,7 +449,10 @@ class Insert(DXFGraphic):
 
         return explode_block_reference(self, target_layout=target_layout)
 
-    def virtual_entities(self, non_uniform_scaling=False) -> Iterable[DXFGraphic]:
+    def virtual_entities(self,
+                         non_uniform_scaling=False,
+                         skipped_entity_callback: Optional[Callable[['DXFGraphic'], None]] = None
+                         ) -> Iterable[DXFGraphic]:
         """
         Yields "virtual" entities of a block reference. This method is meant to examine the block reference
         entities at the "exploded" location without really "exploding" the block reference.
@@ -470,6 +473,7 @@ class Insert(DXFGraphic):
 
         Args:
             non_uniform_scaling: enable non uniform scaling if ``True``, see warning
+            skipped_entity_callback: called whenever the transformation of an entity is not supported and so was skipped
 
         .. versionadded:: 0.12
             experimental feature
@@ -478,7 +482,7 @@ class Insert(DXFGraphic):
         if non_uniform_scaling is False and not self.has_uniform_scaling:
             return []
 
-        return virtual_block_reference_entities(self)
+        return virtual_block_reference_entities(self, skipped_entity_callback=skipped_entity_callback)
 
     def add_auto_attribs(self, values: Dict[str, str]) -> 'Insert':
         """

--- a/src/ezdxf/explode.py
+++ b/src/ezdxf/explode.py
@@ -131,8 +131,7 @@ def virtual_block_reference_entities(block_ref: 'Insert',
         block_ref: Block reference entity (INSERT)
         uniform_scaling_factor: override uniform scaling factor for text entities (TEXT, ATTRIB, MTEXT)  and
                                 HATCH pattern, default is ``max(abs(xscale), abs(yscale),  abs(zscale))``
-        skipped_entity_callback: called whenever the transformation of an entity is not supported and so was
-                                skipped.
+        skipped_entity_callback: called whenever the transformation of an entity is not supported and so was skipped.
 
     .. warning::
 

--- a/src/ezdxf/explode.py
+++ b/src/ezdxf/explode.py
@@ -118,7 +118,7 @@ def angle_to_param(ratio: float, angle: float, quadrant: int = 0) -> float:
 
 def virtual_block_reference_entities(block_ref: 'Insert',
                                      uniform_scaling_factor: float = None,
-                                     skipped_entity_callback: Optional[Callable[['DXFGraphic'], None]] = None
+                                     skipped_entity_callback: Optional[Callable[['DXFGraphic', str], None]] = None
                                      ) -> Iterable['DXFGraphic']:
     """
     Yields 'virtual' parts of block reference `block_ref`. This method is meant to examine the the block reference
@@ -145,14 +145,13 @@ def virtual_block_reference_entities(block_ref: 'Insert',
     assert block_ref.dxftype() == 'INSERT'
     Ellipse = cast('Ellipse', factory.cls('ELLIPSE'))
     if skipped_entity_callback is None:
-        def skipped_entity_callback(_entity):
-            pass
+        def skipped_entity_callback(entity, reason):
+            logger.debug(f'(Virtual Block Reference Entities) Ignoring {str(entity)}: "{reason}"')
 
     def disassemble(layout) -> Generator['DXFGraphic', None, None]:
         for entity in layout:
             dxftype = entity.dxftype()
-            if dxftype == 'ATTDEF':  # do not explode ATTDEF entities
-                skipped_entity_callback(entity)
+            if dxftype == 'ATTDEF':  # do not explode ATTDEF entities. Already available in Insert.attribs
                 continue
 
             if has_non_uniform_scaling:
@@ -174,8 +173,7 @@ def virtual_block_reference_entities(block_ref: 'Insert',
             try:
                 copy = entity.copy()
             except DXFTypeError:
-                logger.debug(f'(Virtual Block Reference Entities) Ignoring non copyable entity {str(entity)}')
-                skipped_entity_callback(entity)
+                skipped_entity_callback(entity, 'non copyable')
                 continue  # non copyable entities will be ignored
 
             if copy.dxftype() == 'HATCH':
@@ -189,8 +187,7 @@ def virtual_block_reference_entities(block_ref: 'Insert',
                     # None uniform scaling produces incorrect results for the arc and ellipse transformations.
                     # This causes an DXF structure error for AutoCAD.
                     # todo: requires testing
-                    logger.debug(f'(Virtual Block Reference Entities) Ignoring {str(entity)} for non uniform scaling.')
-                    skipped_entity_callback(entity)
+                    skipped_entity_callback(entity, 'unsupported non-uniform scaling')
                     continue
 
                     # For the case that arc and ellipse transformation works correct someday:
@@ -248,8 +245,7 @@ def virtual_block_reference_entities(block_ref: 'Insert',
         try:
             entity.transform_to_wcs(brcs)
         except NotImplementedError:  # entities without 'transform_to_wcs' support will be ignored
-            logger.debug(f'(Virtual Block Reference Entities) Ignoring non transformable entity {str(entity)}')
-            skipped_entity_callback(entity)
+            skipped_entity_callback(entity, 'non transformable')
             continue
 
         if has_scaling:
@@ -312,7 +308,7 @@ def virtual_block_reference_entities(block_ref: 'Insert',
                     # hatch.pattern is already scaled by the stored pattern_scale value
                     hatch.set_pattern_definition(hatch.pattern.as_list(), uniform_scaling_factor)
             else:  # unsupported entity will be ignored
-                skipped_entity_callback(entity)
+                skipped_entity_callback(entity, 'unsupported entity')
                 continue
 
         yield entity

--- a/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
+++ b/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
@@ -162,10 +162,15 @@ def test_06_return_skipped_entities(doc, msp):
     blk.add_attdef('attrib')
     blk.add_line((0, 0), (1, 0))
     blkref = msp.add_blockref('test_block', insert=(2, 2))
-    entities = list(virtual_block_reference_entities(blkref, None))
+    skipped_entities = []
+
+    def on_entity_skipped(entity):
+        skipped_entities.append(entity)
+
+    entities = list(virtual_block_reference_entities(blkref, 1.0, skipped_entity_callback=on_entity_skipped))
+
     assert len(entities) == 1
     assert entities[0].dxftype() == 'LINE'
-    skipped_entities = list(virtual_block_reference_entities(blkref, None, only_return_skipped_entities=True))
     assert len(skipped_entities) == 1
     assert skipped_entities[0].dxftype() == 'ATTDEF'
 

--- a/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
+++ b/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
@@ -4,6 +4,8 @@ import pytest
 import ezdxf
 import math
 
+from ezdxf.explode import virtual_block_reference_entities
+
 
 @pytest.fixture(scope='module')
 def doc():
@@ -153,6 +155,19 @@ def test_05_examine_uniform_scaled_ellipse(doc, msp):
     assert ellipse.dxf.center == (2, 2)
     assert ellipse.dxf.major_axis == (4, 0)
     assert ellipse.dxf.ratio == 0.5
+
+
+def test_06_return_skipped_entities(doc, msp):
+    blk = doc.blocks.new('test_block')
+    blk.add_attdef('attrib')
+    blk.add_line((0, 0), (1, 0))
+    blkref = msp.add_blockref('test_block', insert=(2, 2))
+    entities = list(virtual_block_reference_entities(blkref, None))
+    assert len(entities) == 1
+    assert entities[0].dxftype() == 'LINE'
+    skipped_entities = list(virtual_block_reference_entities(blkref, None, only_return_skipped_entities=True))
+    assert len(skipped_entities) == 1
+    assert skipped_entities[0].dxftype() == 'ATTDEF'
 
 
 if __name__ == '__main__':

--- a/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
+++ b/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
@@ -155,22 +155,27 @@ def test_05_examine_uniform_scaled_ellipse(doc, msp):
     assert ellipse.dxf.ratio == 0.5
 
 
-def test_06_return_skipped_entities(doc, msp):
+def test_06_skipped_entities_callback(doc, msp):
     blk = doc.blocks.new('test_block')
-    blk.add_attdef('attrib')
+    hatch = blk.add_hatch()
+    edge_path = hatch.paths.add_edge_path()
+    edge_path.add_arc((0, 0))
     blk.add_line((0, 0), (1, 0))
-    blkref = msp.add_blockref('test_block', insert=(2, 2))
+    blkref = msp.add_blockref('test_block', insert=(0, 0)).place((0, 0), (1, 2, 3))
     skipped_entities = []
 
-    def on_entity_skipped(entity):
-        skipped_entities.append(entity)
+    def on_entity_skipped(entity, reason):
+        skipped_entities.append((entity, reason))
 
-    entities = list(blkref.virtual_entities(skipped_entity_callback=on_entity_skipped))
+    assert not blkref.has_uniform_scaling
+    assert hatch.paths.has_critical_elements()
+    entities = list(blkref.virtual_entities(non_uniform_scaling=True, skipped_entity_callback=on_entity_skipped))
 
     assert len(entities) == 1
     assert entities[0].dxftype() == 'LINE'
     assert len(skipped_entities) == 1
-    assert skipped_entities[0].dxftype() == 'ATTDEF'
+    assert skipped_entities[0][0].dxftype() == 'HATCH'
+    assert skipped_entities[0][1] == 'unsupported non-uniform scaling'
 
 
 if __name__ == '__main__':

--- a/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
+++ b/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
@@ -4,8 +4,6 @@ import pytest
 import ezdxf
 import math
 
-from ezdxf.explode import virtual_block_reference_entities
-
 
 @pytest.fixture(scope='module')
 def doc():
@@ -167,7 +165,7 @@ def test_06_return_skipped_entities(doc, msp):
     def on_entity_skipped(entity):
         skipped_entities.append(entity)
 
-    entities = list(virtual_block_reference_entities(blkref, 1.0, skipped_entity_callback=on_entity_skipped))
+    entities = list(blkref.virtual_entities(skipped_entity_callback=on_entity_skipped))
 
     assert len(entities) == 1
     assert entities[0].dxftype() == 'LINE'


### PR DESCRIPTION
This pull request adds an interface for determining which entities are skipped during expansion of an Insert entity. The implementation perhaps isn't ideal, but it does limit the amount of change to the implementation of `virtual_block_reference_entities()`.