### PR TITLE
ocs_vertices with z && div by zero

### DIFF
--- a/src/ezdxf/entities/hatch.py
+++ b/src/ezdxf/entities/hatch.py
@@ -963,7 +963,7 @@ class EdgePath:
 
 
 def _transform_2d_ocs_vertices(ucs, vertices, elevation, extrusion) -> List[Tuple[float, float]]:
-    ocs_vertices = (Vector(x, y, elevation) for x, y in vertices)
+    ocs_vertices = (Vector(v[0], v[1], elevation) for v in vertices)
     return [(v.x, v.y) for v in ucs.ocs_points_to_ocs(ocs_vertices, extrusion=extrusion)]
 
 

--- a/src/ezdxf/entities/insert.py
+++ b/src/ezdxf/entities/insert.py
@@ -389,11 +389,15 @@ class Insert(DXFGraphic):
         else:
             insert = Vector(insert)
 
+        ez = Vector(self.dxf.extrusion)
+        if ez.magnitude == 0:
+            ez = Vector(0,0,1)
+
         brcs = BRCS(
             insert=ocs.to_wcs(insert),
             ux=ocs.to_wcs(X_AXIS) * sx,
             uy=ocs.to_wcs(Y_AXIS) * sy,
-            uz=Vector(self.dxf.extrusion).normalize(sz),
+            uz=ez.normalize(sz),
         )
         brcs._rotate_local_z(math.radians(self.dxf.rotation))
         block_layout = self.block()

--- a/src/ezdxf/math/ucs.py
+++ b/src/ezdxf/math/ucs.py
@@ -27,7 +27,11 @@ class OCS:
     """
 
     def __init__(self, extrusion: 'Vertex' = Z_AXIS):
-        Az = Vector(extrusion).normalize()
+        Az = Vector(extrusion) #.normalize()
+        if Az.magnitude == 0:
+            Az = Vector(0,0,1)
+        else:
+            Az = Az.normalize()
         self.transform = not Az.isclose(Z_AXIS)
         if self.transform:
             if (abs(Az.x) < 1 / 64.) and (abs(Az.y) < 1 / 64.):
@@ -619,6 +623,10 @@ class BRCS(TransformUSCToOCSMixin):
              angle: rotation angle in radians
 
         """
-        t = Matrix44.axis_rotate(self._matrix.uz.normalize(), angle)
+        if self._matrix.uz.magnitude == 0:
+            z = Vector(0,0,1)
+        else:
+            z = self._matrix.uz.normalize()
+        t = Matrix44.axis_rotate(z, angle)
         ux, uy = t.transform_vectors([self._matrix.ux, self._matrix.uy])
         self._matrix = Matrix33(ux, uy, self._matrix.uz)


### PR DESCRIPTION
1. in `_transform_2d_ocs_vertices`, the vectors might have 3 components.

2. In two cases, the vector along z axis could have 0 length.

My fix is more of a hack and I fear there are other occasions of normalizing 0-length vectors.  It appears to me that extrusion of (0,0,0) is a common cause of this problem.  Maybe such cases should be systematically detected and fixed.