### PR TITLE
Duplicate variable name broke Cython compatibility

### DIFF
--- a/src/ezdxf/sections/acdsdata.py
+++ b/src/ezdxf/sections/acdsdata.py
@@ -169,7 +169,7 @@ class AcDsRecord:
     def __init__(self, tags: Tags):
         self._dxftype = tags[0]
         self.flags = tags[1]
-        self.sections = [Section(tags) for tags in group_tags(islice(tags, 2, None), splitcode=2)]
+        self.sections = [Section(group) for group in group_tags(islice(tags, 2, None), splitcode=2)]
 
     def dxftype(self) -> str:
         return 'ACDSRECORD'


### PR DESCRIPTION
I was trying to get ezdxf to compile with Cython and was getting this error:

File "acdsdata.py", line 172, in ezdxf.sections.acdsdata.AcDsRecord.__init__
UnboundLocalError: local variable 'tags' referenced before assignment

I was able to get it to compile by changing the duplicate variable name from tags to group.

Thanks for all your efforts on this awesome package!

Just in case you are interested: in my application, after compiling with Cython reading the DXF file is about 3x faster than with pure CPython 3.8.