### PR TITLE
Ellipse parameters

### DIFF
--- a/src/ezdxf/math/__init__.py
+++ b/src/ezdxf/math/__init__.py
@@ -6,7 +6,7 @@ from .vector import Vector, Vec2, X_AXIS, Y_AXIS, Z_AXIS, NULLVEC
 from .construct2d import (
     is_close_points, closest_point, convex_hull_2d, intersection_line_line_2d, distance_point_line_2d,
     is_point_on_line_2d, is_point_in_polygon_2d, is_point_left_of_line, point_to_line_relation,
-    rytz_axis_construction, normalize_angle, quadrant,
+    rytz_axis_construction, normalize_angle,
 )
 from .construct3d import (
     is_planar_face, subdivide_face, subdivide_ngons, Plane, LocationState, intersection_ray_ray_3d, normal_vector_3p,

--- a/src/ezdxf/math/construct2d.py
+++ b/src/ezdxf/math/construct2d.py
@@ -109,22 +109,6 @@ def normalize_angle(angle: float) -> float:
     return angle
 
 
-def quadrant(angle: float) -> int:
-    """
-    Returns quadrant of angle (in radians) in range 1 to 4.
-
-    """
-    a = normalize_angle(angle)
-    if a <= RADIANS_90:
-        return 1
-    elif a <= RADIANS_180:
-        return 2
-    elif a <= RADIANS_270:
-        return 3
-    else:
-        return 4
-
-
 def enclosing_angles(angle, start_angle, end_angle, ccw=True, abs_tol=TOLERANCE):
     isclose = partial(math.isclose, abs_tol=abs_tol)
 

--- a/src/ezdxf/math/vector.py
+++ b/src/ezdxf/math/vector.py
@@ -483,6 +483,17 @@ class Vector:
                 raise ValueError(f'domain error: {cos_theta}')
         return math.acos(cos_theta)
 
+    def angle_about(self, a: "Vector", b: "Vector"):
+        """
+        anticlockwise angle about this vector from a to b when projected
+        onto the plane defined by this vector as the normal
+        """
+        x_axis = a.normalize()
+        y_axis = self.cross(x_axis).normalize()
+        b_projected_x = x_axis.dot(b)
+        b_projected_y = y_axis.dot(b)
+        return math.atan2(b_projected_y, b_projected_x) % math.tau
+
     def rotate(self, angle: float) -> 'Vector':
         """
         Returns vector rotated about `angle` around the z-axis.

--- a/tests/test_02_dxf_graphics/test_221_ellipse.py
+++ b/tests/test_02_dxf_graphics/test_221_ellipse.py
@@ -7,7 +7,7 @@ import pytest
 import math
 
 from ezdxf.explode import angle_to_param
-from ezdxf.math import Vector, quadrant
+from ezdxf.math import Vector
 from ezdxf.entities.ellipse import Ellipse
 from ezdxf.lldxf.tagwriter import TagCollector, basic_tags_from_text
 
@@ -164,36 +164,35 @@ def test_swap_axis_half_ellipse():
 
 def test_angle_to_param():
     angle = 1.23
-    assert quadrant(angle) == 1
-    assert math.isclose(angle_to_param(1.0, angle, quadrant(angle)), angle)
+    assert math.isclose(angle_to_param(1.0, angle), angle)
 
     angle = 1.23 + math.pi / 2
-    assert quadrant(angle) == 2
-    assert math.isclose(angle_to_param(1.0, angle, quadrant(angle)), angle)
+    assert math.isclose(angle_to_param(1.0, angle), angle)
 
     angle = 1.23 + math.pi
-    assert quadrant(angle) == 3
-    assert math.isclose(angle_to_param(1.0, angle, quadrant(angle)), angle)
+    assert math.isclose(angle_to_param(1.0, angle), angle)
 
     angle = 1.23 + 3 * math.pi / 2
-    assert quadrant(angle) == 4
-    assert math.isclose(angle_to_param(1.0, angle, quadrant(angle)), angle)
+    assert math.isclose(angle_to_param(1.0, angle), angle)
 
     angle = math.pi / 2 + 1e-15
-    assert quadrant(angle) == 2
-    assert math.isclose(angle_to_param(1.0, angle, quadrant(angle)), angle)
+    assert math.isclose(angle_to_param(1.0, angle), angle)
 
     random.seed(0)
     for i in range(1000):
         ratio = random.uniform(0, 1)
-        angle = random.uniform(0, 2 * math.pi)
-        param = angle_to_param(ratio, angle, quadrant(angle))
+        angle = random.uniform(0, math.tau)
+        param = angle_to_param(ratio, angle)
         ellipse = Ellipse.new(dxfattribs={
-            'major_axis': (1, 0, 0),
+            'major_axis': (random.uniform(-10, 10), random.uniform(-10, 10), 0),
             'ratio': ratio,
             'start_param': 0,
             'end_param': param,
+            'extrusion': (0, 0, random.choice([1, -1])),
         })
-        calculated_angle = ellipse.dxf.major_axis.angle_between(ellipse.end_point)
-        assert math.isclose(calculated_angle, angle)
+        calculated_angle = ellipse.dxf.extrusion.angle_about(ellipse.dxf.major_axis, ellipse.end_point)
+        calculated_angle_without_direction = ellipse.dxf.major_axis.angle_between(ellipse.end_point)
+        assert math.isclose(calculated_angle, angle, abs_tol=1e-5)
+        assert (math.isclose(calculated_angle, calculated_angle_without_direction) or
+                math.isclose(math.tau - calculated_angle, calculated_angle_without_direction))
 

--- a/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
+++ b/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
@@ -1,8 +1,14 @@
 # Copyright (c) 2020, Manfred Moitzi
 # License: MIT License
+from typing import cast
+
 import pytest
 import ezdxf
 import math
+
+from ezdxf.entities import Ellipse
+from ezdxf.explode import angle_to_param
+from ezdxf.math import normalize_angle, Vector
 
 
 @pytest.fixture(scope='module')
@@ -115,18 +121,15 @@ def test_03_explode_polyline_bulge(doc, msp):
     assert e.dxf.end == (3, 0)
 
     e = entities[1]
+    e = cast(Ellipse, e)
     assert e.dxftype() == 'ELLIPSE'
     assert e.dxf.center.isclose((4.5, 0.5625, 0))
     assert e.dxf.major_axis.isclose((1.875, 0.0, 0))
     assert e.dxf.ratio == 0.5
-    assert math.isclose(e.dxf.start_param, -2.498091544796509)
-    assert math.isclose(e.dxf.end_param, -0.6435011087932843)
-    assert math.isclose(e.start_point.x, 3.0)
-    assert math.isclose(e.start_point.y, 0.0)
-    assert math.isclose(e.start_point.z, 0.0)
-    assert math.isclose(e.end_point.x, 6.0)
-    assert math.isclose(e.end_point.y, 0.0, abs_tol=1e-5)
-    assert math.isclose(e.end_point.z, 0.0)
+    assert math.isclose(e.dxf.start_param, -2.498091544796509 % math.tau)
+    assert math.isclose(e.dxf.end_param, -0.6435011087932843 % math.tau)
+    assert e.start_point.isclose(Vector(3, 0, 0))
+    assert e.end_point.isclose(Vector(6, 0, 0), abs_tol=1e-5)
 
     e = entities[2]
     assert e.dxftype() == 'LINE'

--- a/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
+++ b/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
@@ -121,6 +121,12 @@ def test_03_explode_polyline_bulge(doc, msp):
     assert e.dxf.ratio == 0.5
     assert math.isclose(e.dxf.start_param, -2.498091544796509)
     assert math.isclose(e.dxf.end_param, -0.6435011087932843)
+    assert math.isclose(e.start_point.x, 3.0)
+    assert math.isclose(e.start_point.y, 0.0)
+    assert math.isclose(e.start_point.z, 0.0)
+    assert math.isclose(e.end_point.x, 6.0)
+    assert math.isclose(e.end_point.y, 0.0, abs_tol=1e-5)
+    assert math.isclose(e.end_point.z, 0.0)
 
     e = entities[2]
     assert e.dxftype() == 'LINE'

--- a/tests/test_06_math/test_602_vector.py
+++ b/tests/test_06_math/test_602_vector.py
@@ -293,6 +293,24 @@ def test_angle_between():
     assert math.isclose(angle, math.pi)
 
 
+def test_angle_about():
+    extrusion = Vector(0, 0, 1)
+    a = Vector(1, 0, 0)
+    b = Vector(1, 1, 0)
+    assert math.isclose(a.angle_between(b), math.pi / 4)
+    assert math.isclose(extrusion.angle_about(a, b), math.pi / 4)
+
+    extrusion = Vector(0, 0, -1)
+    assert math.isclose(a.angle_between(b), math.pi / 4)
+    assert math.isclose(extrusion.angle_about(a, b), (-math.pi / 4) % math.tau)
+
+    extrusion = Vector(0, 0, 1)
+    a = Vector(1, 1, 0)
+    b = Vector(1, 1, 0)
+    assert math.isclose(a.angle_between(b), 0, abs_tol=1e-5)
+    assert math.isclose(extrusion.angle_about(a, b), 0)
+
+
 def test_cross_product():
     v1 = Vector(2, 7, 9)
     v2 = Vector(3, 9, 1)


### PR DESCRIPTION
I ran into a problem where ellipses inside blocks were sometimes not rendering correctly. One problem contributing to this is that `angle_to_param()` seemed to be returning incorrect parameters for angles close to the boundaries of the quadrants. Replacing this function with my own implementation fixed that issue.
The unit test ensures that if the ratio is 1.0 then param == angle. Another part to the test is that regardless of other ellipse attributes like the choice of major axis, constructing an ellipse with a parameter calculated from an angle then using `ellipse.(start|end)_point` and getting the angle to that point should yield the original angle. This was not the case with the old implementation.

There were additional issues uncovered by the unit test relating to the fact that the parameter angles of transformed ellipses were not taking direction into account (e.g. `axis = Vector(1, 0, 0)`, `axis.angle_between(Vector(1, -0.1, 0)) == axis.angle_between(Vector(1, 0.1, 0))`), and so the start_point or end_point may not be in the correct location because information is being lost.
To fix this I'm obtaining the anticlockwise angle from the major_axis to the start/end points *about the extrusion vector*.