### PR TITLE
Fix reflections

### DIFF
--- a/src/ezdxf/math/vector.py
+++ b/src/ezdxf/math/vector.py
@@ -493,7 +493,7 @@ class Vector:
             base: base vector, defines angle 0
             target: target vector
         """
-        x_axis = base.normalize()
+        x_axis = (base - self.project(base)).normalize()
         y_axis = self.cross(x_axis).normalize()
         target_projected_x = x_axis.dot(target)
         target_projected_y = y_axis.dot(target)

--- a/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
+++ b/tests/test_04_dxf_high_level_structs/test_414_explode_blockrefs.py
@@ -233,7 +233,7 @@ def _check_curve(ellipse: Ellipse, expected_start: Vector, expected_end: Vector,
 # TODO: currently zscale=-1 is failing
 #@pytest.mark.parametrize('zscale,is_arc', [(1, False), (0.5, False), (1, True), (0.5, True), (-1, False), (-1, True)])
 @pytest.mark.parametrize('zscale,is_arc', [(1, False), (0.5, False), (1, True), (0.5, True)])
-def test_07_rotated_and_reflected_ellipses(zscale, is_arc):
+def test_07_rotated_and_reflected_curves(zscale, is_arc):
     scale = Vector(1, 1, zscale)
 
     ellipse = _get_transformed_curve(scale, 0.0, is_arc)
@@ -292,7 +292,7 @@ def test_07_rotated_and_reflected_ellipses(zscale, is_arc):
 
 
 @pytest.mark.parametrize('stretch,is_arc', [(0.5, False), (0.5, True)])
-def test_08_rotated_and_reflected_and_stretched_ellipses(stretch, is_arc):
+def test_08_rotated_and_reflected_and_stretched_curves(stretch, is_arc):
     scale = Vector(1, stretch, 1)
 
     ellipse = _get_transformed_curve(scale, 0.0, is_arc)

--- a/tests/test_06_math/test_602_vector.py
+++ b/tests/test_06_math/test_602_vector.py
@@ -310,6 +310,14 @@ def test_angle_about():
     assert math.isclose(a.angle_between(b), 0, abs_tol=1e-5)
     assert math.isclose(extrusion.angle_about(a, b), 0)
 
+    extrusion = Vector(0, 1, 0)
+    a = Vector(1, 1, 0)
+    b = Vector(0, 1, -1)
+    assert math.isclose(a.angle_between(b), math.pi / 3, abs_tol=1e-5)
+    c = a.cross(b)
+    assert math.isclose(a.angle_between(b), c.angle_about(a, b))
+    assert math.isclose(extrusion.angle_about(a, b), math.pi / 2)
+
 
 def test_cross_product():
     v1 = Vector(2, 7, 9)


### PR DESCRIPTION
I created this CAD file as reference and tried to match the behaviour when encountering reflections. Before my previous patch, the start and end locations were incorrect, after my ellipse patch the start and end points were correct but sometimes the wrong sides of the ellipses were drawn:
[rotated_and_scaled_arcs.dxf.zip](https://github.com/mozman/ezdxf/files/4563963/rotated_and_scaled_arcs.dxf.zip)


AutoCad:
![Screenshot from 2020-05-01 12-29-16](https://user-images.githubusercontent.com/4923501/80802502-68aa1e00-8ba7-11ea-956b-b9f1226eaea5.png)
My rendering after the ellipses patch:
![ellipse_block_4_negative_scaling_and_rotation](https://user-images.githubusercontent.com/4923501/80802560-90998180-8ba7-11ea-80a8-caa341614474.png)
After applying this patch:
![ellipse_block_4_negative_scaling_and_rotation](https://user-images.githubusercontent.com/4923501/80802614-b9ba1200-8ba7-11ea-8110-993e97275b1d.png)

so the ellipses/arcs are correct for all the zscale > 0 cases.
I tried several approaches including negating the extrusion vector, but I found that if a reflected block is exploded in autocad, the extrusion vector is not negated, so instead the ellipse parameters just have to be interpreted differently in the case where a reflection took place. I tried to write logic to perform flips of the start and end parameters when the scale causes a reflection (when Det(scale_matrix) < 0) but I found that just checking whether the start and end have flipped which is bigger is the easiest way to detect that some kind of reflection has occurred.

The text is a bit wrong but I did investigate a little bit to try and fix it, and I don't think the text entities store enough information for them to be reflected outside of a block. if a reflected block is exploded in autocad the text reflection disappears:
![Screenshot from 2020-05-01 12-33-43](https://user-images.githubusercontent.com/4923501/80802767-30570f80-8ba8-11ea-9c67-5618204412a2.png)
exploded:
![image (2)](https://user-images.githubusercontent.com/4923501/80802768-3220d300-8ba8-11ea-9bfa-392f4d87b425.png)


I have written unit tests which cover every cell in the table above, but I've disabled the zscale < 0 tests since those fail at the moment. I did attempt to solve these cases but since the point entities weren't even being transformed correctly I think there is an issue elsewhere with the transformation before the ellipse case can be attempted.

