### PR TITLE
In documentation of the "draw" addon, set "layout" object?

### DIFF
--- a/docs/source/addons/drawing.rst
+++ b/docs/source/addons/drawing.rst
@@ -41,6 +41,7 @@ Example for the usage of the :mod:`matplotlib` backend:
     ax = fig.add_axes([0, 0, 1, 1])
     ctx = RenderContext(doc)
     out = MatplotlibBackend(ax)
+    layout = ezdxf.layouts.Layout(msp,doc)
     Frontend(ctx, out).draw_layout(layout, finalize=True)
     fig.savefig('your.png', dpi=300)
 


### PR DESCRIPTION
I am a total newbie to GitHub, so I hope I'm doing this right.  Also, I'm also new to ezdxf, so be kind regarding the following question/suggestion.

In the documentation of the Draw addon, the code references a "layout" object, but the "layout" object is not initialized, so the code fails.  My pull request attempts to correct this.

Thank you for this awesome package.  I hope this helps!