### PR TITLE
odafc addon improvements

### DIFF
--- a/src/ezdxf/addons/odafc.py
+++ b/src/ezdxf/addons/odafc.py
@@ -1,19 +1,22 @@
 # Copyright (c) 2020, Manfred Moitzi
 # License: MIT License
 # Created: 2020-04-01
-from typing import Optional
 import logging
-import subprocess
 import os
+import platform
+import shutil
+import subprocess
+import tempfile
+import time
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Optional, List
+
 import ezdxf
 from ezdxf.drawing import Drawing
 from ezdxf.lldxf.validator import is_dxf_file, dxf_info, is_binary_dxf_file, dwg_version
 
 logger = logging.getLogger('ezdxf')
-
-exec_path = r"C:\Program Files\ODA\ODAFileConverter\ODAFileConverter.exe"
-temp_path = os.environ['TMP'] or os.environ['TEMP']
 
 
 class ODAFCError(IOError):
@@ -54,17 +57,7 @@ def map_version(version: str) -> str:
     return VERSION_MAP.get(version.upper(), version.upper())
 
 
-# ODA File Converter command line format:
-# ---------------------------------------
-# OdaFC "Input Folder" "Output Folder" version type recurse audit [filter]
-# version - Output version: "ACAD9" - "ACAD2018"
-# type - Output file type: "DWG", "DXF", "DXB"
-# recurse - Recurse Input Folder: "0" or "1"
-# audit - audit each file: "0" or "1"
-# optional Input files filter: default "*.DWG,*.DXF"
-
-
-def readfile(filename: str, version: str = None, audit=False) -> Optional[Drawing]:
+def readfile(filename: str, version: Optional[str] = None, audit: bool = False) -> Optional[Drawing]:
     """
     Use an installed `ODA File Converter`_ to convert a DWG/DXB/DXF file into a temporary DXF file and load
     this file by `ezdxf`.
@@ -77,48 +70,22 @@ def readfile(filename: str, version: str = None, audit=False) -> Optional[Drawin
 
     """
     infile = Path(filename).absolute()
-    if not infile.exists():
-        raise FileNotFoundError(f"No such file or directory: '{infile}'")
-    in_folder = infile.parent
-    name = infile.name
-    ext = infile.suffix.lower()
+    if not infile.is_file():
+        raise FileNotFoundError(f"No such file: '{infile}'")
+    version = _detect_version(filename) if version is None else version
 
-    tmp_folder = Path(temp_path).absolute()
-    if not tmp_folder.exists():
-        tmp_folder.mkdir()
-
-    dxf_temp_file = (tmp_folder / name).with_suffix('.dxf')
-    _version = 'ACAD2018'
-    if ext == '.dxf':
-        if is_binary_dxf_file(str(infile)):
-            pass
-        elif is_dxf_file(str(infile)):
-            with open(filename, 'rt') as fp:
-                info = dxf_info(fp)
-                _version = VERSION_MAP[info.version]
-    elif ext == '.dwg':
-        _version = dwg_version(str(infile))
-        if _version is None:
-            raise ValueError('Unknown or unsupported DWG version.')
-    else:
-        raise ValueError(f"Unsupported file format: '{ext}'")
-
-    if version is None:
-        version = _version
-
-    version = map_version(version)
-    cmd = _odafc_cmd(name, str(in_folder), str(tmp_folder), fmt='DXF', version=version, audit=audit)
-    _execute_odafc(cmd)
-
-    if dxf_temp_file.exists():
-        doc = ezdxf.readfile(str(dxf_temp_file))
-        dxf_temp_file.unlink()
-        doc.filename = infile.with_suffix('.dxf')
-        return doc
-    return None
+    with tempfile.TemporaryDirectory(prefix='odafc_') as tmp_dir:
+        args = _odafc_arguments(infile.name, infile.parent, tmp_dir, output_format='DXF', version=version, audit=audit)
+        _execute_odafc(args)
+        out_file = Path(tmp_dir) / infile.with_suffix('.dxf').name
+        if out_file.exists():
+            doc = ezdxf.readfile(str(out_file))
+            doc.filename = infile.with_suffix('.dxf')
+            return doc
+    raise ODAFCError('Failed to convert file: Unknown Error')
 
 
-def export_dwg(doc: Drawing, filename: str, version=None, audit=False) -> None:
+def export_dwg(doc: Drawing, filename: str, version: Optional[str] = None, audit: bool = False) -> None:
     """
     Use an installed `ODA File Converter`_ to export a DXF document `doc` as a DWG file.
 
@@ -136,41 +103,134 @@ def export_dwg(doc: Drawing, filename: str, version=None, audit=False) -> None:
         version = doc.dxfversion
     export_version = VERSION_MAP[version]
     dwg_file = Path(filename).absolute()
-    dxf_file = Path(temp_path) / dwg_file.with_suffix('.dxf').name
-
-    # Save DXF document
-    old_filename = doc.filename
-    doc.saveas(dxf_file)
-    doc.filename = old_filename
-
     out_folder = Path(dwg_file.parent)
-    try:
-        if out_folder.exists():
-            cmd = _odafc_cmd(dxf_file.name, str(temp_path), str(out_folder), fmt='DWG', version=export_version,
-                             audit=audit)
-            _execute_odafc(cmd)
-        else:
-            raise FileNotFoundError(f"No such file or directory: '{str(out_folder)}'")
-    finally:
-        if dxf_file.exists():
-            dxf_file.unlink()
+    if dwg_file.exists():
+        raise FileExistsError(f'file already exists: {dwg_file}')
+    if out_folder.exists():
+        with tempfile.TemporaryDirectory(prefix='odafc_') as tmp_dir:
+
+            dxf_file = Path(tmp_dir) / dwg_file.with_suffix('.dxf').name
+
+            # Save DXF document
+            old_filename = doc.filename
+            doc.saveas(dxf_file)
+            doc.filename = old_filename
+
+            arguments = _odafc_arguments(dxf_file.name, tmp_dir, str(out_folder),
+                                         output_format='DWG', version=export_version, audit=audit)
+            _execute_odafc(arguments)
+    else:
+        raise FileNotFoundError(f"No such file or directory: '{str(out_folder)}'")
 
 
-def _odafc_cmd(filename: str, in_folder: str, out_folder: str, fmt: str = 'DXF', version='ACAD2013', audit=False):
+def _detect_version(path: str) -> str:
+    version = 'ACAD2018'
+    ext = os.path.splitext(path)[1].lower()
+    if ext == '.dxf':
+        if is_binary_dxf_file(path):
+            pass
+        elif is_dxf_file(path):
+            with open(path, 'rt') as fp:
+                info = dxf_info(fp)
+                version = VERSION_MAP[info.version]
+    elif ext == '.dwg':
+        version = dwg_version(path)
+        if version is None:
+            raise ValueError('Unknown or unsupported DWG version.')
+    else:
+        raise ValueError(f"Unsupported file format: '{ext}'")
+
+    return map_version(version)
+
+
+def _odafc_arguments(filename: str, in_folder: str, out_folder: str, output_format: str = 'DXF',
+                     version: str = 'ACAD2013', audit: bool = False) -> List[str]:
+    """
+    ODA File Converter command line format:
+    ---------------------------------------
+    OdaFC "Input Folder" "Output Folder" version type recurse audit [filter]
+    version - Output version: "ACAD9" - "ACAD2018"
+    type - Output file type: "DWG", "DXF", "DXB"
+    recurse - Recurse Input Folder: "0" or "1"
+    audit - audit each file: "0" or "1"
+    optional Input files filter: default "*.DWG,*.DXF"
+    """
     recurse = '0'
     audit = '1' if audit else '0'
-    return [exec_path, in_folder, out_folder, version, fmt, recurse, audit, filename]
+    return [in_folder, out_folder, version, output_format, recurse, audit, filename]
 
 
-def _execute_odafc(cmd) -> Optional[bytes]:
-    logger.debug(f'run="{cmd}"')
-    # New code from George-Jiang to solve the GUI pop-up problem
-    startupinfo = subprocess.STARTUPINFO()
-    startupinfo.dwFlags = subprocess.CREATE_NEW_CONSOLE | subprocess.STARTF_USESHOWWINDOW
-    startupinfo.wShowWindow = subprocess.SW_HIDE
-    result = subprocess.Popen(args=cmd, stdout=subprocess.PIPE, stderr=None, startupinfo=startupinfo)
-    if result.returncode:
-        msg = f'ODA File Converter returns error code: {result.returncode}'
+def _get_odafc_path(system: str) -> str:
+    path = shutil.which('ODAFileConverter')
+    if not path and system == 'Windows':
+        path = r"C:\Program Files\ODA\ODAFileConverter\ODAFileConverter.exe"
+        if not Path(path).is_file():
+            path = None
+
+    if not path:
+        raise FileNotFoundError(f'Could not find ODAFileConverter in the path. '
+                                f'Install it from https://www.opendesign.com/guestfiles/oda_file_converter')
+    return path
+
+
+@contextmanager
+def _linux_dummy_display():
+    """ see xvbfwrapper library for a more feature complete xvfb interface """
+    if shutil.which('Xvfb'):
+        display = ':123'  # arbitrary choice
+        proc = subprocess.Popen(['Xvfb', display, '-screen', '0', '800x600x24'],
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(0.1)
+        yield display
+        try:
+            proc.terminate()
+            proc.wait()
+        except OSError:
+            pass
+    else:
+        logger.warning(f'install xvfb to prevent the ODAFileConverter GUI from opening')
+        yield os.environ['DISPLAY']
+
+
+def _run_with_no_gui(system: str, command: str, arguments: List[str]) -> subprocess.Popen:
+    if system == 'Linux':
+        with _linux_dummy_display() as display:
+            env = os.environ.copy()
+            env['DISPLAY'] = display
+            proc = subprocess.Popen([command] + arguments, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+            proc.wait()
+
+    elif system == 'Darwin':
+        # TODO: unknown how to prevent the GUI from appearing on OSX
+        proc = subprocess.Popen([command] + arguments, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc.wait()
+
+    elif system == 'Windows':
+        # New code from George-Jiang to solve the GUI pop-up problem
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags = subprocess.CREATE_NEW_CONSOLE | subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = subprocess.SW_HIDE
+        proc = subprocess.Popen([command] + arguments, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                startupinfo=startupinfo)
+        proc.wait()
+
+    else:
+        # ODAFileConverter only has Linux, OSX and Windows versions
+        raise ODAFCError(f'unsupported platform: {system}')
+
+    return proc
+
+
+def _execute_odafc(arguments: List[str]) -> Optional[bytes]:
+    logger.debug(f'running ODAFileConverter with arguments: {arguments}')
+    system = platform.system()
+    oda_fc = _get_odafc_path(system)
+    result = _run_with_no_gui(system, oda_fc, arguments)
+    stdout = result.stdout.read().decode('utf-8')
+    stderr = result.stderr.read().decode('utf-8')
+    if result.returncode != 0 or stderr:  # currently, ODAFileConverter does not set the return code
+        msg = f'ODA File Converter failed: return code = {result.returncode}.\nstdout: {stdout}\nstderr: {stderr}'
         logger.debug(msg)
         raise ODAFCError(msg)
+
     return result.stdout


### PR DESCRIPTION
I saw some activity from pull requests to get the oda file converter addon working on Linux. I have already solved the GUI problem for linux and thought I should share my findings.

Since ezdxf seems to prefer fewer dependencies I didn't use the xvfbwrapper python package but instead wrote a minimal xvfb interface to allow the ODAFileConverter to run inside a dummy X display.

While I was at it I did some refactoring, added some more checks for files already existing and used `shutil.which()` which avoids hard coding paths for linux and hopefully OSX (but Windows might still require the hard coded path). Also TemporaryDirectory is a good cross platform way of obtaining a temporary directory rather than hard coding anything.