### PR TITLE
Improved override and skip entity interfaces

### DIFF
--- a/examples/addons/drawing/cad_viewer.py
+++ b/examples/addons/drawing/cad_viewer.py
@@ -59,7 +59,7 @@ class CADGraphicsView(qw.QGraphicsView):
         scene = self.scene()
         r = scene.sceneRect()
         bx, by = r.width() * self._view_buffer / 2, r.height() * self._view_buffer / 2
-        scene.setSceneRect(r.adjusted(-bx, by, bx, by))
+        scene.setSceneRect(r.adjusted(-bx, -by, bx, by))
 
     def fit_to_scene(self):
         self.fitInView(self.sceneRect(), qc.Qt.KeepAspectRatio)

--- a/examples/addons/drawing/cad_viewer.py
+++ b/examples/addons/drawing/cad_viewer.py
@@ -19,6 +19,7 @@ from ezdxf.addons.drawing.properties import is_dark_color
 from ezdxf.addons.drawing.pyqt import _get_x_scale, PyQtBackend, CorrespondingDXFEntity, \
     CorrespondingDXFEntityStack
 from ezdxf.drawing import Drawing
+from ezdxf.entities import DXFGraphic
 from ezdxf.lldxf.const import DXFStructureError
 
 
@@ -314,16 +315,23 @@ class CadViewer(qw.QMainWindow):
                 text += 'No data'
             else:
                 text += f'Selected Entity: {dxf_entity}\nLayer: {dxf_entity.dxf.layer}\n\nDXF Attributes:\n'
-                for key, value in dxf_entity.dxf.all_existing_dxf_attribs().items():
-                    text += f'- {key}: {value}\n'
+                text += _entity_attribs_string(dxf_entity)
 
                 dxf_entity_stack = element.data(CorrespondingDXFEntityStack)
                 if dxf_entity_stack:
                     text += '\nParents:\n'
                     for entity in reversed(dxf_entity_stack):
                         text += f'- {entity}\n'
+                        text += _entity_attribs_string(entity, indent='    ')
 
         self.selected_info.setPlainText(text)
+
+
+def _entity_attribs_string(dxf_entity: DXFGraphic, indent: str = '') -> str:
+    text = ''
+    for key, value in dxf_entity.dxf.all_existing_dxf_attribs().items():
+        text += f'{indent}- {key}: {value}\n'
+    return text
 
 
 def _main():

--- a/src/ezdxf/addons/drawing/debug_utils.py
+++ b/src/ezdxf/addons/drawing/debug_utils.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from ezdxf.addons.drawing.backend import Backend
+from ezdxf.addons.drawing.type_hints import Color
+from ezdxf.math import Vector
+
+
+def draw_rect(points: List[Vector], color: Color, out: Backend):
+    from ezdxf.addons.drawing import Properties
+
+    props = Properties()
+    props.color = color
+    for a, b in zip(points, points[1:]):
+        out.draw_line(a, b, props)

--- a/src/ezdxf/addons/drawing/frontend.py
+++ b/src/ezdxf/addons/drawing/frontend.py
@@ -151,8 +151,7 @@ class Frontend:
 
         elif dxftype in ('XLINE', 'RAY'):
             start = d.start
-            delta = (Vector(d.unit_vector.x, d.unit_vector.y, 0)
-                     * INFINITE_LINE_LENGTH)
+            delta = d.unit_vector * INFINITE_LINE_LENGTH
             if dxftype == 'XLINE':
                 self.out.draw_line(start - delta / 2, start + delta / 2,
                                    properties)

--- a/src/ezdxf/addons/drawing/properties.py
+++ b/src/ezdxf/addons/drawing/properties.py
@@ -378,8 +378,7 @@ class RenderContext:
         else:  # BYOBJECT
             color = self._true_entity_color(entity.rgb, aci)
 
-        alpha_float = 1.0 - entity.transparency
-        alpha = int(round(alpha_float * 255))
+        alpha = int(round((1.0 - entity.transparency) * 255))
         if alpha == 255:
             return color
         else:

--- a/src/ezdxf/addons/drawing/properties.py
+++ b/src/ezdxf/addons/drawing/properties.py
@@ -363,9 +363,7 @@ class RenderContext:
             layer = self.current_block_reference.layer
         return layer
 
-    def resolve_color(self, entity: 'DXFGraphic', *,
-                      default_hatch_transparency: float = 0.8,
-                      resolved_layer: str = None) -> Color:
+    def resolve_color(self, entity: 'DXFGraphic', *, resolved_layer: str = None) -> Color:
         """ Resolve color of DXF `entity` """
         aci = entity.dxf.color  # defaults to BYLAYER
         if aci == const.BYLAYER:
@@ -380,17 +378,12 @@ class RenderContext:
         else:  # BYOBJECT
             color = self._true_entity_color(entity.rgb, aci)
 
-        if entity.dxftype() == 'HATCH':
-            transparency = default_hatch_transparency
-        else:
-            transparency = entity.transparency
-
-        alpha_float = 1.0 - transparency
+        alpha_float = 1.0 - entity.transparency
         alpha = int(round(alpha_float * 255))
         if alpha == 255:
             return color
         else:
-            return _rgba(color, alpha)
+            return set_color_alpha(color, alpha)
 
     def _true_entity_color(self,
                            true_color: Optional[Tuple[int, int, int]],
@@ -548,10 +541,11 @@ def hex_to_rgb(hex_string: Color) -> RGB:
     return r, g, b
 
 
-def _rgba(color: Color, alpha: int) -> Color:
+def set_color_alpha(color: Color, alpha: int) -> Color:
     """
     Args:
-        color: may be an RGB or RGBA color
+        color: may be an RGB or RGBA hex color string
+        alpha: the new alpha value (0-255)
     """
     assert color.startswith('#') and len(color) in (7, 9), f'invalid RGB color: "{color}"'
     assert 0 <= alpha < 255, f'alpha out of range: {alpha}'

--- a/src/ezdxf/addons/drawing/text.py
+++ b/src/ezdxf/addons/drawing/text.py
@@ -8,8 +8,8 @@ from math import radians
 from typing import Union, Tuple, Dict, Iterable, List, Optional, Callable
 
 import ezdxf.lldxf.const as DXFConstants
-from ezdxf.addons.drawing import Properties
 from ezdxf.addons.drawing.backend import Backend
+from ezdxf.addons.drawing.debug_utils import draw_rect
 from ezdxf.entities import MText, Text, Attrib
 from ezdxf.math import Matrix44, Vector
 
@@ -290,7 +290,4 @@ def simplified_text_chunks(text: AnyText, out: Backend,
             width = out.get_text_line_width(line, cap_height)
             ps = list(transform.transform_vertices([Vector(0, 0, 0), Vector(width, 0, 0), Vector(width, cap_height, 0),
                                                     Vector(0, cap_height, 0), Vector(0, 0, 0)]))
-            props = Properties()
-            props.color = '#ff0000'
-            for a, b in zip(ps, ps[1:]):
-                out.draw_line(a, b, props)
+            draw_rect(ps, '#ff0000', out)

--- a/src/ezdxf/addons/drawing/text.py
+++ b/src/ezdxf/addons/drawing/text.py
@@ -8,6 +8,7 @@ from math import radians
 from typing import Union, Tuple, Dict, Iterable, List, Optional, Callable
 
 import ezdxf.lldxf.const as DXFConstants
+from ezdxf.addons.drawing import Properties
 from ezdxf.addons.drawing.backend import Backend
 from ezdxf.entities import MText, Text, Attrib
 from ezdxf.math import Matrix44, Vector
@@ -289,5 +290,7 @@ def simplified_text_chunks(text: AnyText, out: Backend,
             width = out.get_text_line_width(line, cap_height)
             ps = list(transform.transform_vertices([Vector(0, 0, 0), Vector(width, 0, 0), Vector(width, cap_height, 0),
                                                     Vector(0, cap_height, 0), Vector(0, 0, 0)]))
+            props = Properties()
+            props.color = '#ff0000'
             for a, b in zip(ps, ps[1:]):
-                out.draw_line(a, b, '#ff0000')
+                out.draw_line(a, b, props)


### PR DESCRIPTION
I think it makes sense for the override interface to be implemented by inheriting from the frontend. Do you agree? I think in most cases the front end is a single-use object so assigning different override functions to it seems unnecessary. Also, by making it a method of the frontend, the filter has access to the current rendering context as well which could be useful.

I also moved the hack to set hatch transparency into the override method since that is a good use case for this method, and it means that the value returned from `resolve_color` is accurate. I also changed the skip_entity interface to pass in the entity itself which is more useful than just a message.