### PR TITLE
handling of invalid escape codes

### DIFF
--- a/src/ezdxf/entities/mtext.py
+++ b/src/ezdxf/entities/mtext.py
@@ -377,13 +377,18 @@ def plain_mtext(text: str, split=False) -> Union[List[str], str]:
                     # discard other commands
             else:  # more character commands are terminated by ';'
                 stacking = char == 'S'  # stacking command surrounds user data
+                first_char = char
+                search_chars = raw_chars.copy()
                 try:
                     while char != ';':  # end of format marker
-                        char = raw_chars.pop()
+                        char = search_chars.pop()
                         if stacking and char != ';':
                             chars.append(char)  # append user data of stacking command
+                    raw_chars = search_chars
                 except IndexError:
-                    break  # premature end of text - just ignore
+                    # premature end of text - just ignore
+                    chars.append('\\')
+                    chars.append(first_char)
         elif char in '{}':  # grouping
             pass  # discard group markers
         elif char == '%':  # special characters

--- a/tests/test_02_dxf_graphics/test_225_mtext.py
+++ b/tests/test_02_dxf_graphics/test_225_mtext.py
@@ -282,6 +282,8 @@ def test_mtext_plain_text():
     expected = "Das ist eine MText\nZeile mit Formatierung\nänder die Farbe\n1.^INummerierung\n2.^INummerierung\n\n1/2500  ein Bruch"
     assert plain_mtext(raw_text) == expected
 
+    assert plain_mtext('\\:') == '\\:'  # invalid escape code is printed verbatim
+
 
 def test_mtext_plain_text_special_char():
     assert plain_mtext("%%d") == "°"


### PR DESCRIPTION
I was generating a dxf file and comparing the output in autocad vs cad_viewer and found that one of the MText entities wasn't being drawn. I looked into it and found the cause was an invalid escape code `\:` which I had accidentally introduced (but which wasn't causing any errors or warnings anywhere). In this situation AutoCAD renders the text as-is, whereas ezdxf returns `""` from `plain_text()`. This change returns the text as-is if a stacking command cannot be parsed before the end of the string.

```python
import ezdxf

if __name__ == '__main__':
    doc = ezdxf.new()
    msp = doc.modelspace()

    t = msp.add_mtext('\\: abcdef')
    print(t.plain_text())
```