### PR TITLE
Added caret notation support

### DIFF
--- a/examples_dxf/caret_encoding.dxf
+++ b/examples_dxf/caret_encoding.dxf
@@ -1,0 +1,4440 @@
+  0
+SECTION
+  2
+HEADER
+  9
+$ACADVER
+  1
+AC1027
+  9
+$ACADMAINTVER
+ 70
+105
+  9
+$DWGCODEPAGE
+  3
+ANSI_1252
+  9
+$LASTSAVEDBY
+  1
+ezdxf
+  9
+$REQUIREDVERSIONS
+160
+0
+  9
+$INSBASE
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$EXTMIN
+ 10
+-100
+ 20
+-100
+ 30
+-100
+  9
+$EXTMAX
+ 10
+100
+ 20
+100
+ 30
+100
+  9
+$LIMMIN
+ 10
+0.0
+ 20
+0.0
+  9
+$LIMMAX
+ 10
+420.0
+ 20
+297.0
+  9
+$ORTHOMODE
+ 70
+0
+  9
+$REGENMODE
+ 70
+1
+  9
+$FILLMODE
+ 70
+1
+  9
+$QTEXTMODE
+ 70
+0
+  9
+$MIRRTEXT
+ 70
+1
+  9
+$LTSCALE
+ 40
+1.0
+  9
+$ATTMODE
+ 70
+1
+  9
+$TEXTSIZE
+ 40
+2.5
+  9
+$TRACEWID
+ 40
+1.0
+  9
+$TEXTSTYLE
+  7
+Standard
+  9
+$CLAYER
+  8
+0
+  9
+$CELTYPE
+  6
+ByLayer
+  9
+$CECOLOR
+ 62
+256
+  9
+$CELTSCALE
+ 40
+1.0
+  9
+$DISPSILH
+ 70
+0
+  9
+$DIMSCALE
+ 40
+1.0
+  9
+$DIMASZ
+ 40
+2.5
+  9
+$DIMEXO
+ 40
+0.625
+  9
+$DIMDLI
+ 40
+3.75
+  9
+$DIMRND
+ 40
+0.0
+  9
+$DIMDLE
+ 40
+0.0
+  9
+$DIMEXE
+ 40
+1.25
+  9
+$DIMTP
+ 40
+0.0
+  9
+$DIMTM
+ 40
+0.0
+  9
+$DIMTXT
+ 40
+2.5
+  9
+$DIMCEN
+ 40
+2.5
+  9
+$DIMTSZ
+ 40
+0.0
+  9
+$DIMTOL
+ 70
+0
+  9
+$DIMLIM
+ 70
+0
+  9
+$DIMTIH
+ 70
+0
+  9
+$DIMTOH
+ 70
+0
+  9
+$DIMSE1
+ 70
+0
+  9
+$DIMSE2
+ 70
+0
+  9
+$DIMTAD
+ 70
+1
+  9
+$DIMZIN
+ 70
+8
+  9
+$DIMBLK
+  1
+
+  9
+$DIMASO
+ 70
+1
+  9
+$DIMSHO
+ 70
+1
+  9
+$DIMPOST
+  1
+
+  9
+$DIMAPOST
+  1
+
+  9
+$DIMALT
+ 70
+0
+  9
+$DIMALTD
+ 70
+3
+  9
+$DIMALTF
+ 40
+0.03937007874
+  9
+$DIMLFAC
+ 40
+1.0
+  9
+$DIMTOFL
+ 70
+1
+  9
+$DIMTVP
+ 40
+0.0
+  9
+$DIMTIX
+ 70
+0
+  9
+$DIMSOXD
+ 70
+0
+  9
+$DIMSAH
+ 70
+0
+  9
+$DIMBLK1
+  1
+
+  9
+$DIMBLK2
+  1
+
+  9
+$DIMSTYLE
+  2
+ISO-25
+  9
+$DIMCLRD
+ 70
+0
+  9
+$DIMCLRE
+ 70
+0
+  9
+$DIMCLRT
+ 70
+0
+  9
+$DIMTFAC
+ 40
+1.0
+  9
+$DIMGAP
+ 40
+0.625
+  9
+$DIMJUST
+ 70
+0
+  9
+$DIMSD1
+ 70
+0
+  9
+$DIMSD2
+ 70
+0
+  9
+$DIMTOLJ
+ 70
+0
+  9
+$DIMTZIN
+ 70
+8
+  9
+$DIMALTZ
+ 70
+0
+  9
+$DIMALTTZ
+ 70
+0
+  9
+$DIMUPT
+ 70
+0
+  9
+$DIMDEC
+ 70
+2
+  9
+$DIMTDEC
+ 70
+2
+  9
+$DIMALTU
+ 70
+2
+  9
+$DIMALTTD
+ 70
+3
+  9
+$DIMTXSTY
+  7
+Standard
+  9
+$DIMAUNIT
+ 70
+0
+  9
+$DIMADEC
+ 70
+0
+  9
+$DIMALTRND
+ 40
+0.0
+  9
+$DIMAZIN
+ 70
+0
+  9
+$DIMDSEP
+ 70
+44
+  9
+$DIMATFIT
+ 70
+3
+  9
+$DIMFRAC
+ 70
+0
+  9
+$DIMLDRBLK
+  1
+
+  9
+$DIMLUNIT
+ 70
+2
+  9
+$DIMLWD
+ 70
+-2
+  9
+$DIMLWE
+ 70
+-2
+  9
+$DIMTMOVE
+ 70
+0
+  9
+$DIMFXL
+ 40
+1.0
+  9
+$DIMFXLON
+ 70
+0
+  9
+$DIMJOGANG
+ 40
+0.785398163397
+  9
+$DIMTFILL
+ 70
+0
+  9
+$DIMTFILLCLR
+ 70
+0
+  9
+$DIMARCSYM
+ 70
+0
+  9
+$DIMLTYPE
+  6
+
+  9
+$DIMLTEX1
+  6
+
+  9
+$DIMLTEX2
+  6
+
+  9
+$DIMTXTDIRECTION
+ 70
+0
+  9
+$LUNITS
+ 70
+2
+  9
+$LUPREC
+ 70
+4
+  9
+$SKETCHINC
+ 40
+1.0
+  9
+$FILLETRAD
+ 40
+10.0
+  9
+$AUNITS
+ 70
+0
+  9
+$AUPREC
+ 70
+2
+  9
+$MENU
+  1
+.
+  9
+$ELEVATION
+ 40
+0.0
+  9
+$PELEVATION
+ 40
+0.0
+  9
+$THICKNESS
+ 40
+0.0
+  9
+$LIMCHECK
+ 70
+0
+  9
+$CHAMFERA
+ 40
+0.0
+  9
+$CHAMFERB
+ 40
+0.0
+  9
+$CHAMFERC
+ 40
+0.0
+  9
+$CHAMFERD
+ 40
+0.0
+  9
+$SKPOLY
+ 70
+0
+  9
+$TDCREATE
+ 40
+2459059.7159953704
+  9
+$TDUCREATE
+ 40
+2458532.153996898
+  9
+$TDUPDATE
+ 40
+2459059.7159953704
+  9
+$TDUUPDATE
+ 40
+2458532.1544311
+  9
+$TDINDWG
+ 40
+0.0
+  9
+$TDUSRTIMER
+ 40
+0.0
+  9
+$USRTIMER
+ 70
+1
+  9
+$ANGBASE
+ 50
+0.0
+  9
+$ANGDIR
+ 70
+0
+  9
+$PDMODE
+ 70
+0
+  9
+$PDSIZE
+ 40
+0.0
+  9
+$PLINEWID
+ 40
+0.0
+  9
+$SPLFRAME
+ 70
+0
+  9
+$SPLINETYPE
+ 70
+6
+  9
+$SPLINESEGS
+ 70
+8
+  9
+$HANDSEED
+  5
+6A
+  9
+$SURFTAB1
+ 70
+6
+  9
+$SURFTAB2
+ 70
+6
+  9
+$SURFTYPE
+ 70
+6
+  9
+$SURFU
+ 70
+6
+  9
+$SURFV
+ 70
+6
+  9
+$UCSBASE
+  2
+
+  9
+$UCSNAME
+  2
+
+  9
+$UCSORG
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSXDIR
+ 10
+1.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSYDIR
+ 10
+0.0
+ 20
+1.0
+ 30
+0.0
+  9
+$UCSORTHOREF
+  2
+
+  9
+$UCSORTHOVIEW
+ 70
+0
+  9
+$UCSORGTOP
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGBOTTOM
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGLEFT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGRIGHT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGFRONT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGBACK
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSBASE
+  2
+
+  9
+$PUCSNAME
+  2
+
+  9
+$PUCSORG
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSXDIR
+ 10
+1.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSYDIR
+ 10
+0.0
+ 20
+1.0
+ 30
+0.0
+  9
+$PUCSORTHOREF
+  2
+
+  9
+$PUCSORTHOVIEW
+ 70
+0
+  9
+$PUCSORGTOP
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGBOTTOM
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGLEFT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGRIGHT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGFRONT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGBACK
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$USERI1
+ 70
+0
+  9
+$USERI2
+ 70
+0
+  9
+$USERI3
+ 70
+0
+  9
+$USERI4
+ 70
+0
+  9
+$USERI5
+ 70
+0
+  9
+$USERR1
+ 40
+0.0
+  9
+$USERR2
+ 40
+0.0
+  9
+$USERR3
+ 40
+0.0
+  9
+$USERR4
+ 40
+0.0
+  9
+$USERR5
+ 40
+0.0
+  9
+$WORLDVIEW
+ 70
+1
+  9
+$SHADEDGE
+ 70
+3
+  9
+$SHADEDIF
+ 70
+70
+  9
+$TILEMODE
+ 70
+1
+  9
+$MAXACTVP
+ 70
+64
+  9
+$PINSBASE
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PLIMCHECK
+ 70
+0
+  9
+$PEXTMIN
+ 10
+1e+20
+ 20
+1e+20
+ 30
+1e+20
+  9
+$PEXTMAX
+ 10
+-1e+20
+ 20
+-1e+20
+ 30
+-1e+20
+  9
+$PLIMMIN
+ 10
+0.0
+ 20
+0.0
+  9
+$PLIMMAX
+ 10
+420.0
+ 20
+297.0
+  9
+$UNITMODE
+ 70
+0
+  9
+$VISRETAIN
+ 70
+1
+  9
+$PLINEGEN
+ 70
+0
+  9
+$PSLTSCALE
+ 70
+1
+  9
+$TREEDEPTH
+ 70
+3020
+  9
+$CMLSTYLE
+  2
+Standard
+  9
+$CMLJUST
+ 70
+0
+  9
+$CMLSCALE
+ 40
+20.0
+  9
+$PROXYGRAPHICS
+ 70
+1
+  9
+$MEASUREMENT
+ 70
+1
+  9
+$CELWEIGHT
+370
+-1
+  9
+$ENDCAPS
+280
+0
+  9
+$JOINSTYLE
+280
+0
+  9
+$LWDISPLAY
+290
+0
+  9
+$INSUNITS
+ 70
+6
+  9
+$HYPERLINKBASE
+  1
+
+  9
+$STYLESHEET
+  1
+
+  9
+$XEDIT
+290
+1
+  9
+$CEPSNTYPE
+380
+0
+  9
+$PSTYLEMODE
+290
+1
+  9
+$FINGERPRINTGUID
+  2
+EE860DBA-D0EC-11EA-9A7E-00C0CA96BA8D
+  9
+$VERSIONGUID
+  2
+EE865E96-D0EC-11EA-9A7E-00C0CA96BA8D
+  9
+$EXTNAMES
+290
+1
+  9
+$PSVPSCALE
+ 40
+0.0
+  9
+$OLESTARTUP
+290
+0
+  9
+$SORTENTS
+280
+127
+  9
+$INDEXCTL
+280
+0
+  9
+$HIDETEXT
+280
+1
+  9
+$XCLIPFRAME
+280
+2
+  9
+$HALOGAP
+280
+0
+  9
+$OBSCOLOR
+ 70
+257
+  9
+$OBSLTYPE
+280
+0
+  9
+$INTERSECTIONDISPLAY
+280
+0
+  9
+$INTERSECTIONCOLOR
+ 70
+257
+  9
+$DIMASSOC
+280
+2
+  9
+$PROJECTNAME
+  1
+
+  9
+$CAMERADISPLAY
+290
+0
+  9
+$LENSLENGTH
+ 40
+50.0
+  9
+$CAMERAHEIGHT
+ 40
+0.0
+  9
+$STEPSPERSEC
+ 40
+24.0
+  9
+$STEPSIZE
+ 40
+100.0
+  9
+$3DDWFPREC
+ 40
+2.0
+  9
+$PSOLWIDTH
+ 40
+0.005
+  9
+$PSOLHEIGHT
+ 40
+0.08
+  9
+$LOFTANG1
+ 40
+1.570796326795
+  9
+$LOFTANG2
+ 40
+1.570796326795
+  9
+$LOFTMAG1
+ 40
+0.0
+  9
+$LOFTMAG2
+ 40
+0.0
+  9
+$LOFTPARAM
+ 70
+7
+  9
+$LOFTNORMALS
+280
+1
+  9
+$LATITUDE
+ 40
+37.795
+  9
+$LONGITUDE
+ 40
+-122.394
+  9
+$NORTHDIRECTION
+ 40
+0.0
+  9
+$TIMEZONE
+ 70
+-8000
+  9
+$LIGHTGLYPHDISPLAY
+280
+1
+  9
+$TILEMODELIGHTSYNCH
+280
+1
+  9
+$CMATERIAL
+347
+20
+  9
+$SOLIDHIST
+280
+0
+  9
+$SHOWHIST
+280
+1
+  9
+$DWFFRAME
+280
+2
+  9
+$DGNFRAME
+280
+2
+  9
+$REALWORLDSCALE
+290
+1
+  9
+$INTERFERECOLOR
+ 62
+256
+  9
+$CSHADOW
+280
+0
+  9
+$SHADOWPLANELOCATION
+ 40
+0.0
+  0
+ENDSEC
+  0
+SECTION
+  2
+CLASSES
+  0
+CLASS
+  1
+ACDBDICTIONARYWDFLT
+  2
+AcDbDictionaryWithDefault
+  3
+ObjectDBX Classes
+ 90
+0
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+SUN
+  2
+AcDbSun
+  3
+SCENEOE
+ 90
+1153
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+VISUALSTYLE
+  2
+AcDbVisualStyle
+  3
+ObjectDBX Classes
+ 90
+4095
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+MATERIAL
+  2
+AcDbMaterial
+  3
+ObjectDBX Classes
+ 90
+1153
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+SCALE
+  2
+AcDbScale
+  3
+ObjectDBX Classes
+ 90
+1153
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+TABLESTYLE
+  2
+AcDbTableStyle
+  3
+ObjectDBX Classes
+ 90
+4095
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+MLEADERSTYLE
+  2
+AcDbMLeaderStyle
+  3
+ACDB_MLEADERSTYLE_CLASS
+ 90
+4095
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+DICTIONARYVAR
+  2
+AcDbDictionaryVar
+  3
+ObjectDBX Classes
+ 90
+0
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+CELLSTYLEMAP
+  2
+AcDbCellStyleMap
+  3
+ObjectDBX Classes
+ 90
+1152
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+MENTALRAYRENDERSETTINGS
+  2
+AcDbMentalRayRenderSettings
+  3
+SCENEOE
+ 90
+1024
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+ACDBDETAILVIEWSTYLE
+  2
+AcDbDetailViewStyle
+  3
+ObjectDBX Classes
+ 90
+1025
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+ACDBSECTIONVIEWSTYLE
+  2
+AcDbSectionViewStyle
+  3
+ObjectDBX Classes
+ 90
+1025
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+RASTERVARIABLES
+  2
+AcDbRasterVariables
+  3
+ISM
+ 90
+0
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+ACDBPLACEHOLDER
+  2
+AcDbPlaceHolder
+  3
+ObjectDBX Classes
+ 90
+0
+ 91
+0
+280
+0
+281
+0
+  0
+CLASS
+  1
+LAYOUT
+  2
+AcDbLayout
+  3
+ObjectDBX Classes
+ 90
+0
+ 91
+0
+280
+0
+281
+0
+  0
+ENDSEC
+  0
+SECTION
+  2
+TABLES
+  0
+TABLE
+  2
+VPORT
+  5
+8
+330
+0
+100
+AcDbSymbolTable
+ 70
+1
+  0
+VPORT
+  5
+23
+330
+8
+100
+AcDbSymbolTableRecord
+100
+AcDbViewportTableRecord
+  2
+*Active
+ 70
+0
+ 10
+0.0
+ 20
+0.0
+ 11
+1.0
+ 21
+1.0
+ 12
+70.0
+ 22
+50.0
+ 13
+0.0
+ 23
+0.0
+ 14
+0.5
+ 24
+0.5
+ 15
+0.5
+ 25
+0.5
+ 16
+0.0
+ 26
+0.0
+ 36
+1.0
+ 17
+0.0
+ 27
+0.0
+ 37
+0.0
+ 40
+1.0
+ 41
+1.34
+ 42
+50.0
+ 43
+0.0
+ 44
+0.0
+ 50
+0.0
+ 51
+0.0
+ 71
+0
+ 72
+1000
+ 73
+1
+ 74
+3
+ 75
+0
+ 76
+0
+ 77
+0
+ 78
+0
+281
+0
+ 65
+0
+146
+0.0
+  0
+ENDTAB
+  0
+TABLE
+  2
+LTYPE
+  5
+2
+330
+0
+100
+AcDbSymbolTable
+ 70
+3
+  0
+LTYPE
+  5
+24
+330
+2
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+ByBlock
+ 70
+0
+  3
+
+ 72
+65
+ 73
+0
+ 40
+0.0
+  0
+LTYPE
+  5
+25
+330
+2
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+ByLayer
+ 70
+0
+  3
+
+ 72
+65
+ 73
+0
+ 40
+0.0
+  0
+LTYPE
+  5
+26
+330
+2
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+Continuous
+ 70
+0
+  3
+
+ 72
+65
+ 73
+0
+ 40
+0.0
+  0
+ENDTAB
+  0
+TABLE
+  2
+LAYER
+  5
+1
+330
+0
+100
+AcDbSymbolTable
+ 70
+2
+  0
+LAYER
+  5
+27
+330
+1
+100
+AcDbSymbolTableRecord
+100
+AcDbLayerTableRecord
+  2
+0
+ 70
+0
+ 62
+7
+  6
+Continuous
+370
+-3
+390
+13
+347
+21
+  0
+LAYER
+  5
+28
+330
+1
+100
+AcDbSymbolTableRecord
+100
+AcDbLayerTableRecord
+  2
+Defpoints
+ 70
+0
+ 62
+7
+  6
+Continuous
+290
+0
+370
+-3
+390
+13
+347
+21
+  0
+ENDTAB
+  0
+TABLE
+  2
+STYLE
+  5
+5
+330
+0
+100
+AcDbSymbolTable
+ 70
+1
+  0
+STYLE
+  5
+29
+330
+5
+100
+AcDbSymbolTableRecord
+100
+AcDbTextStyleTableRecord
+  2
+Standard
+ 70
+0
+ 40
+0.0
+ 41
+1.0
+ 50
+0.0
+ 71
+0
+ 42
+2.5
+  3
+txt
+  4
+
+  0
+ENDTAB
+  0
+TABLE
+  2
+VIEW
+  5
+7
+330
+0
+100
+AcDbSymbolTable
+ 70
+0
+  0
+ENDTAB
+  0
+TABLE
+  2
+UCS
+  5
+6
+330
+0
+100
+AcDbSymbolTable
+ 70
+0
+  0
+ENDTAB
+  0
+TABLE
+  2
+APPID
+  5
+3
+330
+0
+100
+AcDbSymbolTable
+ 70
+1
+  0
+APPID
+  5
+2A
+330
+3
+100
+AcDbSymbolTableRecord
+100
+AcDbRegAppTableRecord
+  2
+ACAD
+ 70
+0
+  0
+ENDTAB
+  0
+TABLE
+  2
+DIMSTYLE
+  5
+4
+330
+0
+100
+AcDbSymbolTable
+ 70
+1
+100
+AcDbDimStyleTable
+  0
+DIMSTYLE
+105
+2B
+330
+4
+100
+AcDbSymbolTableRecord
+100
+AcDbDimStyleTableRecord
+  2
+Standard
+ 70
+0
+ 40
+1.0
+ 41
+2.5
+ 42
+0.625
+ 43
+3.75
+ 44
+1.25
+ 45
+0.0
+ 46
+0.0
+ 47
+0.0
+ 48
+0.0
+ 49
+2.5
+140
+2.5
+141
+2.5
+142
+0.0
+143
+0.03937007874
+144
+1.0
+145
+0.0
+146
+1.0
+147
+0.625
+148
+0.0
+ 69
+0
+ 70
+0
+ 71
+0
+ 72
+0
+ 73
+0
+ 74
+0
+ 75
+0
+ 76
+0
+ 77
+1
+ 78
+8
+ 79
+0
+170
+0
+171
+3
+172
+1
+173
+0
+174
+0
+175
+0
+176
+0
+177
+0
+178
+0
+179
+0
+271
+0
+272
+2
+273
+2
+274
+3
+275
+0
+276
+0
+277
+2
+278
+44
+279
+0
+280
+0
+281
+0
+282
+0
+283
+0
+284
+8
+285
+0
+286
+0
+288
+0
+289
+3
+290
+0
+371
+-2
+372
+-2
+  0
+ENDTAB
+  0
+TABLE
+  2
+BLOCK_RECORD
+  5
+9
+330
+0
+100
+AcDbSymbolTable
+ 70
+2
+  0
+BLOCK_RECORD
+  5
+17
+330
+9
+100
+AcDbSymbolTableRecord
+100
+AcDbBlockTableRecord
+  2
+*Model_Space
+340
+1A
+ 70
+0
+280
+1
+281
+0
+  0
+BLOCK_RECORD
+  5
+1B
+330
+9
+100
+AcDbSymbolTableRecord
+100
+AcDbBlockTableRecord
+  2
+*Paper_Space
+340
+1E
+ 70
+0
+280
+1
+281
+0
+  0
+ENDTAB
+  0
+ENDSEC
+  0
+SECTION
+  2
+BLOCKS
+  0
+BLOCK
+  5
+18
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockBegin
+  2
+*Model_Space
+ 70
+0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+*Model_Space
+  1
+
+  0
+ENDBLK
+  5
+19
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockEnd
+  0
+BLOCK
+  5
+1C
+330
+1B
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockBegin
+  2
+*Paper_Space
+ 70
+0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+*Paper_Space
+  1
+
+  0
+ENDBLK
+  5
+1D
+330
+1B
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockEnd
+  0
+ENDSEC
+  0
+SECTION
+  2
+ENTITIES
+  0
+MTEXT
+  5
+2D
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+a: abc^adef
+  0
+MTEXT
+  5
+2E
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-4.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+b: abc^bdef
+  0
+MTEXT
+  5
+2F
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-8.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+c: abc^cdef
+  0
+MTEXT
+  5
+30
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-12.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+d: abc^ddef
+  0
+MTEXT
+  5
+31
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-16.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+e: abc^edef
+  0
+MTEXT
+  5
+32
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-20.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+f: abc^fdef
+  0
+MTEXT
+  5
+33
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-24.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+g: abc^gdef
+  0
+MTEXT
+  5
+34
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-28.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+h: abc^hdef
+  0
+MTEXT
+  5
+35
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-32.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+i: abc^idef
+  0
+MTEXT
+  5
+36
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-36.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+j: abc^jdef
+  0
+MTEXT
+  5
+37
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-40.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+k: abc^kdef
+  0
+MTEXT
+  5
+38
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-44.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+l: abc^ldef
+  0
+MTEXT
+  5
+39
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-48.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+m: abc^mdef
+  0
+MTEXT
+  5
+3A
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-52.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+n: abc^ndef
+  0
+MTEXT
+  5
+3B
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-56.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+o: abc^odef
+  0
+MTEXT
+  5
+3C
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-60.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+p: abc^pdef
+  0
+MTEXT
+  5
+3D
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-64.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+q: abc^qdef
+  0
+MTEXT
+  5
+3E
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-68.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+r: abc^rdef
+  0
+MTEXT
+  5
+3F
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-72.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+s: abc^sdef
+  0
+MTEXT
+  5
+40
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-76.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+t: abc^tdef
+  0
+MTEXT
+  5
+41
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-80.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+u: abc^udef
+  0
+MTEXT
+  5
+42
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-84.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+v: abc^vdef
+  0
+MTEXT
+  5
+43
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-88.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+w: abc^wdef
+  0
+MTEXT
+  5
+44
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-92.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+x: abc^xdef
+  0
+MTEXT
+  5
+45
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-96.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+y: abc^ydef
+  0
+MTEXT
+  5
+46
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+0.0
+ 20
+-100.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+z: abc^zdef
+  0
+MTEXT
+  5
+47
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+0.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+A: abc^Adef
+  0
+MTEXT
+  5
+48
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-4.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+B: abc^Bdef
+  0
+MTEXT
+  5
+49
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-8.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+C: abc^Cdef
+  0
+MTEXT
+  5
+4A
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-12.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+D: abc^Ddef
+  0
+MTEXT
+  5
+4B
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-16.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+E: abc^Edef
+  0
+MTEXT
+  5
+4C
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-20.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+F: abc^Fdef
+  0
+MTEXT
+  5
+4D
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-24.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+G: abc^Gdef
+  0
+MTEXT
+  5
+4E
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-28.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+H: abc^Hdef
+  0
+MTEXT
+  5
+4F
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-32.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+I: abc^Idef
+  0
+MTEXT
+  5
+50
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-36.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+J: abc^Jdef
+  0
+MTEXT
+  5
+51
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-40.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+K: abc^Kdef
+  0
+MTEXT
+  5
+52
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-44.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+L: abc^Ldef
+  0
+MTEXT
+  5
+53
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-48.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+M: abc^Mdef
+  0
+MTEXT
+  5
+54
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-52.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+N: abc^Ndef
+  0
+MTEXT
+  5
+55
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-56.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+O: abc^Odef
+  0
+MTEXT
+  5
+56
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-60.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+P: abc^Pdef
+  0
+MTEXT
+  5
+57
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-64.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+Q: abc^Qdef
+  0
+MTEXT
+  5
+58
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-68.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+R: abc^Rdef
+  0
+MTEXT
+  5
+59
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-72.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+S: abc^Sdef
+  0
+MTEXT
+  5
+5A
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-76.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+T: abc^Tdef
+  0
+MTEXT
+  5
+5B
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-80.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+U: abc^Udef
+  0
+MTEXT
+  5
+5C
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-84.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+V: abc^Vdef
+  0
+MTEXT
+  5
+5D
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-88.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+W: abc^Wdef
+  0
+MTEXT
+  5
+5E
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-92.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+X: abc^Xdef
+  0
+MTEXT
+  5
+5F
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-96.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+Y: abc^Ydef
+  0
+MTEXT
+  5
+60
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+40.0
+ 20
+-100.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+Z: abc^Zdef
+  0
+MTEXT
+  5
+61
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+80.0
+ 20
+0.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+?: abc^?def
+  0
+MTEXT
+  5
+62
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+80.0
+ 20
+-4.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+@: abc^@def
+  0
+MTEXT
+  5
+63
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+80.0
+ 20
+-8.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+[: abc^[def
+  0
+MTEXT
+  5
+64
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+80.0
+ 20
+-12.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+]: abc^]def
+  0
+MTEXT
+  5
+65
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+80.0
+ 20
+-16.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+\: abc^\def
+  0
+MTEXT
+  5
+66
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+80.0
+ 20
+-20.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+_: abc^_def
+  0
+MTEXT
+  5
+67
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+80.0
+ 20
+-24.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+ : abc^ def
+  0
+MTEXT
+  5
+68
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+80.0
+ 20
+-28.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+^ : abc^^def
+  0
+MTEXT
+  5
+69
+330
+17
+100
+AcDbEntity
+  8
+0
+100
+AcDbMText
+ 10
+80.0
+ 20
+-32.0
+ 30
+0.0
+ 40
+2.5
+ 71
+1
+  1
+^
+  0
+ENDSEC
+  0
+SECTION
+  2
+OBJECTS
+  0
+DICTIONARY
+  5
+A
+330
+0
+100
+AcDbDictionary
+281
+1
+  3
+ACAD_COLOR
+350
+B
+  3
+ACAD_GROUP
+350
+C
+  3
+ACAD_LAYOUT
+350
+D
+  3
+ACAD_MATERIAL
+350
+E
+  3
+ACAD_MLEADERSTYLE
+350
+F
+  3
+ACAD_MLINESTYLE
+350
+10
+  3
+ACAD_PLOTSETTINGS
+350
+11
+  3
+ACAD_PLOTSTYLENAME
+350
+12
+  3
+ACAD_SCALELIST
+350
+14
+  3
+ACAD_TABLESTYLE
+350
+15
+  3
+ACAD_VISUALSTYLE
+350
+16
+  0
+DICTIONARY
+  5
+B
+330
+A
+100
+AcDbDictionary
+281
+1
+  0
+DICTIONARY
+  5
+C
+330
+A
+100
+AcDbDictionary
+281
+1
+  0
+DICTIONARY
+  5
+D
+330
+A
+100
+AcDbDictionary
+281
+1
+  3
+Model
+350
+1A
+  3
+Layout1
+350
+1E
+  0
+DICTIONARY
+  5
+E
+330
+A
+100
+AcDbDictionary
+281
+1
+  3
+ByBlock
+350
+1F
+  3
+ByLayer
+350
+20
+  3
+Global
+350
+21
+  0
+DICTIONARY
+  5
+F
+330
+A
+100
+AcDbDictionary
+281
+1
+  3
+Standard
+350
+2C
+  0
+DICTIONARY
+  5
+10
+330
+A
+100
+AcDbDictionary
+281
+1
+  3
+Standard
+350
+22
+  0
+DICTIONARY
+  5
+11
+330
+A
+100
+AcDbDictionary
+281
+1
+  0
+ACDBDICTIONARYWDFLT
+  5
+12
+330
+A
+100
+AcDbDictionary
+281
+1
+  3
+Normal
+350
+13
+100
+AcDbDictionaryWithDefault
+340
+13
+  0
+ACDBPLACEHOLDER
+  5
+13
+330
+12
+  0
+DICTIONARY
+  5
+14
+330
+A
+100
+AcDbDictionary
+281
+1
+  0
+DICTIONARY
+  5
+15
+330
+A
+100
+AcDbDictionary
+281
+1
+  0
+DICTIONARY
+  5
+16
+330
+A
+100
+AcDbDictionary
+281
+1
+  0
+LAYOUT
+  5
+1A
+330
+D
+100
+AcDbPlotSettings
+  1
+
+  2
+Adobe PDF
+  4
+A4
+  6
+
+ 40
+3.175
+ 41
+3.175
+ 42
+3.175
+ 43
+3.175
+ 44
+209.91
+ 45
+297.03
+ 46
+0.0
+ 47
+0.0
+ 48
+0.0
+ 49
+0.0
+140
+0.0
+141
+0.0
+142
+1.0
+143
+1.0
+ 70
+1024
+ 72
+0
+ 73
+1
+ 74
+5
+  7
+
+ 75
+16
+ 76
+0
+ 77
+2
+ 78
+300
+147
+1.0
+148
+0.0
+149
+0.0
+100
+AcDbLayout
+  1
+Model
+ 70
+1
+ 71
+0
+ 10
+-3.175
+ 20
+-3.175
+ 11
+293.857
+ 21
+206.735
+ 12
+0.0
+ 22
+0.0
+ 32
+0.0
+ 14
+29.068
+ 24
+20.356
+ 34
+0.0
+ 15
+261.614
+ 25
+183.204
+ 35
+0.0
+146
+0.0
+ 13
+0.0
+ 23
+0.0
+ 33
+0.0
+ 16
+1.0
+ 26
+0.0
+ 36
+0.0
+ 17
+0.0
+ 27
+1.0
+ 37
+0.0
+ 76
+1
+330
+17
+  0
+LAYOUT
+  5
+1E
+330
+D
+100
+AcDbPlotSettings
+  1
+
+  2
+Adobe PDF
+  4
+A4
+  6
+
+ 40
+3.175
+ 41
+3.175
+ 42
+3.175
+ 43
+3.175
+ 44
+209.91
+ 45
+297.03
+ 46
+0.0
+ 47
+0.0
+ 48
+0.0
+ 49
+0.0
+140
+0.0
+141
+0.0
+142
+1.0
+143
+1.0
+ 70
+0
+ 72
+0
+ 73
+1
+ 74
+5
+  7
+
+ 75
+16
+ 76
+0
+ 77
+2
+ 78
+300
+147
+1.0
+148
+0.0
+149
+0.0
+100
+AcDbLayout
+  1
+Layout1
+ 70
+1
+ 71
+1
+ 10
+-3.175
+ 20
+-3.175
+ 11
+293.857
+ 21
+206.735
+ 12
+0.0
+ 22
+0.0
+ 32
+0.0
+ 14
+29.068
+ 24
+20.356
+ 34
+0.0
+ 15
+261.614
+ 25
+183.204
+ 35
+0.0
+146
+0.0
+ 13
+0.0
+ 23
+0.0
+ 33
+0.0
+ 16
+1.0
+ 26
+0.0
+ 36
+0.0
+ 17
+0.0
+ 27
+1.0
+ 37
+0.0
+ 76
+1
+330
+1B
+  0
+MATERIAL
+  5
+1F
+102
+{ACAD_REACTORS
+330
+E
+102
+}
+330
+E
+100
+AcDbMaterial
+  1
+ByBlock
+  2
+
+ 70
+0
+ 40
+1.0
+ 71
+1
+ 41
+1.0
+ 91
+-1023410177
+ 42
+1.0
+ 72
+1
+  3
+
+ 73
+1
+ 74
+1
+ 75
+1
+ 44
+0.5
+ 73
+0
+ 45
+1.0
+ 46
+1.0
+ 77
+1
+  4
+
+ 78
+1
+ 79
+1
+170
+1
+ 48
+1.0
+171
+1
+  6
+
+172
+1
+173
+1
+174
+1
+140
+1.0
+141
+1.0
+175
+1
+  7
+
+176
+1
+177
+1
+178
+1
+143
+1.0
+179
+1
+  8
+
+270
+1
+271
+1
+272
+1
+145
+1.0
+146
+1.0
+273
+1
+  9
+
+274
+1
+275
+1
+276
+1
+ 42
+1.0
+ 72
+1
+  3
+
+ 73
+1
+ 74
+1
+ 75
+1
+ 94
+63
+  0
+MATERIAL
+  5
+20
+102
+{ACAD_REACTORS
+330
+E
+102
+}
+330
+E
+100
+AcDbMaterial
+  1
+ByLayer
+  2
+
+ 70
+0
+ 40
+1.0
+ 71
+1
+ 41
+1.0
+ 91
+-1023410177
+ 42
+1.0
+ 72
+1
+  3
+
+ 73
+1
+ 74
+1
+ 75
+1
+ 44
+0.5
+ 73
+0
+ 45
+1.0
+ 46
+1.0
+ 77
+1
+  4
+
+ 78
+1
+ 79
+1
+170
+1
+ 48
+1.0
+171
+1
+  6
+
+172
+1
+173
+1
+174
+1
+140
+1.0
+141
+1.0
+175
+1
+  7
+
+176
+1
+177
+1
+178
+1
+143
+1.0
+179
+1
+  8
+
+270
+1
+271
+1
+272
+1
+145
+1.0
+146
+1.0
+273
+1
+  9
+
+274
+1
+275
+1
+276
+1
+ 42
+1.0
+ 72
+1
+  3
+
+ 73
+1
+ 74
+1
+ 75
+1
+ 94
+63
+  0
+MATERIAL
+  5
+21
+102
+{ACAD_REACTORS
+330
+E
+102
+}
+330
+E
+100
+AcDbMaterial
+  1
+Global
+  2
+
+ 70
+0
+ 40
+1.0
+ 71
+1
+ 41
+1.0
+ 91
+-1023410177
+ 42
+1.0
+ 72
+1
+  3
+
+ 73
+1
+ 74
+1
+ 75
+1
+ 44
+0.5
+ 73
+0
+ 45
+1.0
+ 46
+1.0
+ 77
+1
+  4
+
+ 78
+1
+ 79
+1
+170
+1
+ 48
+1.0
+171
+1
+  6
+
+172
+1
+173
+1
+174
+1
+140
+1.0
+141
+1.0
+175
+1
+  7
+
+176
+1
+177
+1
+178
+1
+143
+1.0
+179
+1
+  8
+
+270
+1
+271
+1
+272
+1
+145
+1.0
+146
+1.0
+273
+1
+  9
+
+274
+1
+275
+1
+276
+1
+ 42
+1.0
+ 72
+1
+  3
+
+ 73
+1
+ 74
+1
+ 75
+1
+ 94
+63
+  0
+MLINESTYLE
+  5
+22
+102
+{ACAD_REACTORS
+330
+10
+102
+}
+330
+10
+100
+AcDbMlineStyle
+  2
+Standard
+ 70
+0
+  3
+
+ 62
+256
+ 51
+90.0
+ 52
+90.0
+ 71
+2
+ 49
+0.5
+ 62
+256
+  6
+BYLAYER
+ 49
+-0.5
+ 62
+256
+  6
+BYLAYER
+  0
+MLEADERSTYLE
+  5
+2C
+102
+{ACAD_REACTORS
+330
+F
+102
+}
+330
+F
+100
+AcDbMLeaderStyle
+179
+2
+170
+2
+171
+1
+172
+0
+ 90
+2
+ 40
+0.0
+ 41
+0.0
+173
+1
+ 91
+-1056964608
+ 92
+-2
+290
+1
+ 42
+2.0
+291
+1
+ 43
+8.0
+  3
+Standard
+ 44
+4.0
+300
+
+342
+29
+174
+1
+175
+1
+176
+0
+178
+1
+ 93
+-1056964608
+ 45
+4.0
+292
+0
+297
+0
+ 46
+4.0
+ 94
+-1056964608
+ 47
+1.0
+ 49
+0.0
+140
+1.0
+294
+1
+141
+0.0
+177
+0
+142
+1.0
+295
+0
+296
+0
+143
+3.75
+271
+0
+272
+9
+272
+9
+  0
+ENDSEC
+  0
+EOF

--- a/examples_dxf/create_caret_encoding.py
+++ b/examples_dxf/create_caret_encoding.py
@@ -1,0 +1,24 @@
+import ezdxf
+
+doc = ezdxf.new()
+msp = doc.modelspace()
+
+width = 40
+height = 4
+
+for i in range(26):
+    c = chr(ord('a') + i)
+    msp.add_mtext(f'{c}: abc^{c}def', {'insert': (0, -i * height, 0)})
+
+for i in range(26):
+    c = chr(ord('A') + i)
+    msp.add_mtext(f'{c}: abc^{c}def', {'insert': (width, -i * height, 0)})
+
+for i, c in enumerate(['?', '@', '[', ']', '\\', '_', ' ']):
+    msp.add_mtext(f'{c}: abc^{c}def', {'insert': (2 * width, -i * height, 0)})
+
+msp.add_mtext(f'^ : abc^^def', {'insert': (2 * width, -(i + 1) * height, 0)})
+msp.add_mtext('^', {'insert': (2 * width, -(i + 2) * height, 0)})
+
+doc.saveas('caret_encoding.dxf')
+

--- a/src/ezdxf/entities/mtext.py
+++ b/src/ezdxf/entities/mtext.py
@@ -496,7 +496,7 @@ def caret_decode(text: str) -> str:
 
      see: <https://en.wikipedia.org/wiki/Caret_notation>
      """
-    def replace_match(match: re.Match) -> str:
+    def replace_match(match: "re.Match") -> str:
         c = ord(match.group(1))
         return chr((c - 64) % 126)
 

--- a/src/ezdxf/entities/mtext.py
+++ b/src/ezdxf/entities/mtext.py
@@ -1,15 +1,16 @@
 # Copyright (c) 2019-2020 Manfred Moitzi
 # License: MIT License
 # Created 2019-03-06
-from typing import TYPE_CHECKING, Union, Tuple, List
 import math
+import re
+from typing import TYPE_CHECKING, Union, Tuple, List
 
-from ezdxf.math import Vector, Matrix44, OCS
-from ezdxf.math.transformtools import transform_extrusion
 from ezdxf.lldxf import const
 from ezdxf.lldxf.attributes import DXFAttr, DXFAttributes, DefSubclass, XType
 from ezdxf.lldxf.const import SUBCLASS_MARKER, DXF2000, SPECIAL_CHARS_ENCODING
 from ezdxf.lldxf.tags import Tags
+from ezdxf.math import Vector, Matrix44, OCS
+from ezdxf.math.transformtools import transform_extrusion
 from ezdxf.tools.rgb import rgb2int
 from .dxfentity import base_class, SubclassProcessor
 from .dxfgfx import DXFGraphic, acdb_entity
@@ -176,12 +177,11 @@ class MText(DXFGraphic):
             if tag.code == 3:
                 parts.append(tag.value)
         parts.append(tail)
-        self.text = normalize_line_breaks("".join(parts))
+        self.text = _dxf_encode_line_endings(caret_decode("".join(parts)))
         tags.remove_tags((1, 3))
 
     def export_mtext(self, tagwriter: 'TagWriter') -> None:
-        # replacing '\n' and '\r' by '\P' is required, else an invalid DXF file would be created
-        txt = self.text.replace('\n', '\\P').replace('\r', '\\P')
+        txt = _dxf_encode_line_endings(self.text)
         str_chunks = split_mtext_string(txt, size=250)
         if len(str_chunks) == 0:
             str_chunks.append("")
@@ -484,9 +484,28 @@ def split_mtext_string(s: str, size: int = 250) -> List[str]:
             return chunks
 
 
-def normalize_line_breaks(text: str) -> str:
-    """ Replaces '^J', '^M' and '^M^J' by '\\P' """
-    text = text.replace('^M^J', '\\P')
-    text = text.replace('^M', '\\P')
-    text = text.replace('^J', '\\P')
-    return text
+def _dxf_encode_line_endings(text: str) -> str:
+    # replacing '\r\n' and '\n' by '\P' is required, else an invalid DXF file would be created
+    # \r on it's own is not counted as a line ending
+    return text.replace('\r', '').replace('\n', '\\P')
+
+
+def caret_decode(text: str) -> str:
+    """ dxf stores some special characters using caret notation. This function decodes this notation to normalise
+    the representation of special characters in the string
+
+     see: <https://en.wikipedia.org/wiki/Caret_notation>
+     """
+    def replace_match(match: re.Match) -> str:
+        c = ord(match.group(1))
+        return chr((c - 64) % 126)
+
+    return re.sub(r'\^(.)', replace_match, text)
+
+
+def _is_non_printable(char: str) -> bool:
+    return 0 <= ord(char) < 32 and char != '\t'
+
+
+def replace_non_printable_characters(text: str, replacement: str = '▯') -> str:
+    return ''.join(replacement if _is_non_printable(c) else c for c in text)


### PR DESCRIPTION
earlier, support for `^M` and `^J` was added to ezdxf, however this is just a special case of a broader capability of the dxf format to encode characters in so-called '[caret notation](https://en.wikipedia.org/wiki/Caret_notation)'. For example `'^a' == '!'`

I have extended support to hopefully support any caret-encoded string that might be encountered. In the dxf files I have access to I have only seen `^J`, `^I` and `^ ` but full support is better. The `(c - 64) % 126` formula was reverse engineered from what I saw AutoCAD produce and looking at ASCII tables.

Decoding is now done in two steps, first the caret-encoded characters are decoded, then if those characters are newlines they are re-encoded in dxf encoding (`\P`).

Also, when drawing these strings, non-printable characters can be replaced with a rectangle character. This matches the behaviour of AutoCAD quite well, however there are a few differences (see `examples/caret_encoding.dxf`)
several non-printable characters have different behaviour in AutoCAD such as `^B`, `^@`, `^\` `^]`. I also haven't exhaustively checked all possible escape characters. Only the ones which Wikipedia said were valid to be used with caret notation.
- `^@` is special as it encodes for the null character, so presumably AutoCAD uses C-style null terminated strings which is why ^@ ends the string. I didn't replicate this behaviour but you could if you wanted to.

AutoCAD rendering of examples/caret_encoding.dxf
![image (3)](https://user-images.githubusercontent.com/4923501/88689800-d86e6d00-d0f2-11ea-907f-9011a94407f1.png)

ezdxf rendering of a later version of the same file
![caret](https://user-images.githubusercontent.com/4923501/88692588-2638a480-d0f6-11ea-95d3-bff76392c8e1.png)

