### PR TITLE
Added caret support in TEXT entity

### DIFF
--- a/src/ezdxf/addons/drawing/backend.py
+++ b/src/ezdxf/addons/drawing/backend.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple, TYPE_CHECKING, Iterable
 from ezdxf.addons.drawing.properties import Properties
 from ezdxf.addons.drawing.type_hints import Color
 from ezdxf.entities import DXFGraphic
+from ezdxf.entities.mtext import replace_non_printable_characters
 from ezdxf.math import Vector, Matrix44
 from ezdxf.render.path import Path
 
@@ -93,3 +94,16 @@ class Backend(ABC):
 
     def finalize(self) -> None:
         pass
+
+
+def prepare_string_for_rendering(text: str, dxftype: str) -> str:
+    assert '\n' not in text, 'not a single line of text'
+    if dxftype == 'TEXT':
+        text = replace_non_printable_characters(text, replacement='?')
+        text = text.replace('\t', '?')
+    elif dxftype == 'MTEXT':
+        text = replace_non_printable_characters(text, replacement='▯')
+        text = text.replace('\t', '        ')
+    else:
+        raise TypeError(dxftype)
+    return text

--- a/src/ezdxf/entities/mtext.py
+++ b/src/ezdxf/entities/mtext.py
@@ -196,11 +196,11 @@ class MText(DXFGraphic):
             if tag.code == 3:
                 parts.append(tag.value)
         parts.append(tail)
-        self.text = _dxf_encode_line_endings(caret_decode("".join(parts)))
+        self.text = _dxf_escape_line_endings(caret_decode("".join(parts)))
         tags.remove_tags((1, 3))
 
     def export_mtext(self, tagwriter: 'TagWriter') -> None:
-        txt = _dxf_encode_line_endings(self.text)
+        txt = _dxf_escape_line_endings(self.text)
         str_chunks = split_mtext_string(txt, size=250)
         if len(str_chunks) == 0:
             str_chunks.append("")
@@ -518,9 +518,10 @@ def split_mtext_string(s: str, size: int = 250) -> List[str]:
             return chunks
 
 
-def _dxf_encode_line_endings(text: str) -> str:
-    # replacing '\r\n' and '\n' by '\P' is required, else an invalid DXF file
-    # would be created \r on it's own is not counted as a line ending
+def _dxf_escape_line_endings(text: str) -> str:
+    # replacing '\r\n' and '\n' by '\P' is required when exporting, else an
+    # invalid DXF file would be created.
+    # \r on it's own is not counted as a line ending
     return text.replace('\r', '').replace('\n', '\\P')
 
 

--- a/tests/test_02_dxf_graphics/test_206_text.py
+++ b/tests/test_02_dxf_graphics/test_206_text.py
@@ -257,3 +257,7 @@ def test_plain_text():
     assert plain_text('%u%d%') == '%u%d%'
     t = Text.new(dxfattribs={'text': '45%%d'})
     assert t.plain_text() == '45°'
+
+    assert plain_text('abc^a') == 'abc!'
+    assert plain_text('abc^Jdef') == 'abcdef'
+    assert plain_text('abc^@def') == 'abc\0def'

--- a/tests/test_02_dxf_graphics/test_225_mtext.py
+++ b/tests/test_02_dxf_graphics/test_225_mtext.py
@@ -4,12 +4,12 @@
 import pytest
 from ezdxf.entities.mtext import (
     MText, split_mtext_string, plain_mtext, caret_decode,
-    _dxf_encode_line_endings, replace_non_printable_characters,
+    _dxf_escape_line_endings, replace_non_printable_characters
 )
+from ezdxf.layouts import VirtualLayout
 from ezdxf.lldxf import const
 from ezdxf.lldxf.tagwriter import TagCollector, basic_tags_from_text
 from ezdxf.tools.rgb import rgb2int
-from ezdxf.layouts import VirtualLayout
 
 MTEXT = """0
 MTEXT
@@ -304,12 +304,12 @@ def test_transform_interface():
     assert mtext.dxf.insert == (2, 2, 3)
 
 
-def test_dxf_line_ending_encoding():
-    assert _dxf_encode_line_endings('\\P test') == '\\P test'
-    assert _dxf_encode_line_endings('abc\ndef') == 'abc\\Pdef'
-    assert _dxf_encode_line_endings('abc\rdef') == 'abcdef', \
+def test_dxf_escape_line_endings():
+    assert _dxf_escape_line_endings('\\P test') == '\\P test'
+    assert _dxf_escape_line_endings('abc\ndef') == 'abc\\Pdef'
+    assert _dxf_escape_line_endings('abc\rdef') == 'abcdef', \
         r"a single '\r' should be ignored"
-    assert _dxf_encode_line_endings('abc\r\ndef') == 'abc\\Pdef', \
+    assert _dxf_escape_line_endings('abc\r\ndef') == 'abc\\Pdef', \
         r"'\r\n' represents a single newline"
 
 


### PR DESCRIPTION
I realised that my last pull request left some things unfinished because TEXT entities should also support caret encoding.
It turns out that they do, but handle them slightly differently.
- non-printable characters are replaced with `?` rather than `▯`
- fewer characters are supported in TEXT, for example `\t` is replaced with `?`
- `\n` does have an effect, but seems to not be intended behaviour to allow this so I just remove `\n`

There is also a difference in that MText strings can end with a `^` and still be valid and rendered correctly, however a `Text` ending with `^` will be invalid and AutoCAD will refuse to load the file. I added a check for this during export but I'm not sure where the best place to put this check is, so you might want to move it.

AutoCAD rendering
![image (4)](https://user-images.githubusercontent.com/4923501/88789274-76634580-d18e-11ea-9c69-e5aaaa9ed4a7.png)
ezdxf rendering
![caret](https://user-images.githubusercontent.com/4923501/88789283-78c59f80-d18e-11ea-85a3-9d840f5659e6.png)
