### PR TITLE
Drawing

### DIFF
--- a/docs/source/tables/layer_table_entry.rst
+++ b/docs/source/tables/layer_table_entry.rst
@@ -64,7 +64,8 @@ Factory function         :meth:`Drawing.layers.new`
 
     .. attribute:: dxf.plot
 
-        Plot flag (int)
+        Plot flag (int). Whether entities belonging to this layer should be drawn when the document is exported
+        (plotted) to pdf. Does not affect visibility inside the CAD application itself.
 
         === ============================
         1   plot layer (default value)

--- a/examples/addons/drawing/cad_viewer.py
+++ b/examples/addons/drawing/cad_viewer.py
@@ -17,7 +17,7 @@ from ezdxf.addons import odafc
 from ezdxf.addons.drawing import Frontend, RenderContext
 from ezdxf.addons.drawing.properties import is_dark_color
 from ezdxf.addons.drawing.pyqt import _get_x_scale, PyQtBackend, CorrespondingDXFEntity, \
-    CorrespondingDXFEntityStack
+    CorrespondingDXFParentStack
 from ezdxf.drawing import Drawing
 from ezdxf.entities import DXFGraphic
 from ezdxf.lldxf.const import DXFStructureError
@@ -317,10 +317,10 @@ class CadViewer(qw.QMainWindow):
                 text += f'Selected Entity: {dxf_entity}\nLayer: {dxf_entity.dxf.layer}\n\nDXF Attributes:\n'
                 text += _entity_attribs_string(dxf_entity)
 
-                dxf_entity_stack = element.data(CorrespondingDXFEntityStack)
-                if dxf_entity_stack:
+                dxf_parent_stack = element.data(CorrespondingDXFParentStack)
+                if dxf_parent_stack:
                     text += '\nParents:\n'
-                    for entity in reversed(dxf_entity_stack):
+                    for entity in reversed(dxf_parent_stack):
                         text += f'- {entity}\n'
                         text += _entity_attribs_string(entity, indent='    ')
 

--- a/src/ezdxf/addons/drawing/matplotlib.py
+++ b/src/ezdxf/addons/drawing/matplotlib.py
@@ -115,8 +115,7 @@ class MatplotlibBackend(Backend):
         text = prepare_string_for_rendering(text, self.current_entity.dxftype())
         path = _text_path(text, self.font)
         scale = cap_height / self._font_measurements.cap_height
-        transformed_xs = _transform_path(path, Matrix44.scale(scale)).vertices[:, 0].tolist()
-        return max(transformed_xs)
+        return max(x for x, y in path.vertices) * scale
 
     def clear(self):
         self.ax.clear()

--- a/src/ezdxf/addons/drawing/pyqt.py
+++ b/src/ezdxf/addons/drawing/pyqt.py
@@ -39,7 +39,7 @@ class _Point(qw.QAbstractGraphicsShapeItem):
 
 
 CorrespondingDXFEntity = 0  # the key used to store the dxf entity corresponding to each graphics element
-CorrespondingDXFEntityStack = 1
+CorrespondingDXFParentStack = 1
 
 
 class PyQtBackend(Backend):
@@ -81,7 +81,8 @@ class PyQtBackend(Backend):
 
     def _set_item_data(self, item: qw.QGraphicsItem) -> None:
         item.setData(CorrespondingDXFEntity, self.current_entity)
-        item.setData(CorrespondingDXFEntityStack, self.current_entity_stack)
+        parent_stack = tuple(e for e, props in self.entity_stack[:-1])
+        item.setData(CorrespondingDXFParentStack, parent_stack)
 
     def set_background(self, color: Color):
         self.scene.setBackgroundBrush(qg.QBrush(self._get_color(color)))

--- a/src/ezdxf/addons/drawing/pyqt.py
+++ b/src/ezdxf/addons/drawing/pyqt.py
@@ -10,7 +10,6 @@ from ezdxf.addons.drawing.backend import Backend, prepare_string_for_rendering
 from ezdxf.addons.drawing.text import FontMeasurements
 from ezdxf.addons.drawing.type_hints import Color
 from ezdxf.addons.drawing.properties import Properties
-from ezdxf.entities.mtext import replace_non_printable_characters
 from ezdxf.math import Vector, Matrix44
 from ezdxf.render import Path, Command
 


### PR DESCRIPTION
handling entry/exit events is more powerful than just knowing the current entity, so I moved the entity stack handling to the backend to accommodate this. 

I made a few changes to visibility detection and added tests to reflect my findings:
- 'frozen' layers behave mostly like 'off' layers in AutoCAD. There are some differences which I've ignored for now.
- the 'plot' flag doesn't affect visibility until you plot/export a CAD file. I've added an `export_mode` parameter to `RenderContext` to allow the user to specify whether they want to draw the file as it appears in a CAD application, or how it appears on paper.
    - In future, this parameter could influence more things (for example in my testing, line weight makes no difference unless plotting/exporting)
- I saw in the docs that ATTRIB entities have an `is_invisible` property which is independent of `dxf.invisible`. I've added support for this. I'm not sure if any other entities have similar flags.