### PR TITLE
added support for interpreting some kinds of geodata

### DIFF
--- a/docs/source/dxfobjects/geodata.rst
+++ b/docs/source/dxfobjects/geodata.rst
@@ -55,11 +55,14 @@ Required DXF version     R2010 (``'AC1024'``)
 
     .. attribute:: dxf.reference_point
 
-        Reference point in coordinate system coordinates, valid only when coordinate type is `local grid`.
+        Reference point in geo coordinates, valid only when coordinate type is `local grid`.
+        The difference between `dxf.design_point` and `dxf.reference_point` defines the translation
+        from WCS coordinates to geo-coordinates.
 
     .. attribute:: dxf.north_direction
 
-        North direction as 2D vector.
+        North direction as 2D vector. Defines the rotation (about the `dxf.design_point`) to transform
+        from WCS coordinates to geo-coordinates
 
     .. attribute:: dxf.horizontal_unit_scale
 
@@ -71,13 +74,13 @@ Required DXF version     R2010 (``'AC1024'``)
 
     .. attribute:: dxf.horizontal_units
 
-        Horizontal units per UnitsValue enumeration. Will be kUnitsUndefined if units specified by horizontal
-        unit scale is not supported by AutoCAD enumeration.
+        Horizontal units (see  :class:`~ezdxf.entities.BlockRecord`). Will be 0 (Unitless) if units specified
+        by horizontal unit scale is not supported by AutoCAD enumeration.
 
     .. attribute:: dxf.vertical_units
 
-        Vertical units per UnitsValue enumeration. Will be kUnitsUndefined if units specified by vertical unit scale
-        is not supported by AutoCAD enumeration.
+        Vertical units (see :class:`~ezdxf.entities.BlockRecord`). Will be 0 (Unitless) if units specified by
+        vertical unit scale is not supported by AutoCAD enumeration.
 
     .. attribute:: dxf.up_direction
 
@@ -112,11 +115,13 @@ Required DXF version     R2010 (``'AC1024'``)
 
     .. attribute:: source_vertices
 
-        2D source vertices as :class:`~ezdxf.lldxf.packedtags.VertexArray`.
+        2D source vertices in the CRS of the GeoData as :class:`~ezdxf.lldxf.packedtags.VertexArray`.
+        Used together with `target_vertices` to define the transformation from the CRS of the GeoData to WGS84.
 
     .. attribute:: target_vertices
 
-        2D target vertices as :class:`~ezdxf.lldxf.packedtags.VertexArray`.
+        2D target vertices in WGS84 (EPSG:4326) as :class:`~ezdxf.lldxf.packedtags.VertexArray`.
+        Used together with `source_vertices` to define the transformation from the CRS of the geoData to WGS84.
 
     .. attribute:: faces
 
@@ -124,6 +129,7 @@ Required DXF version     R2010 (``'AC1024'``)
 
     .. attribute:: coordinate_system_definition
 
-        The coordinate system definition string. (Always a XML string?)
+        The coordinate system definition string. Stored as XML. Defines the CRS used by the GeoData.
+        The EPSG number and other details like the axis-ordering of the CRS is stored.
 
 

--- a/src/ezdxf/document.py
+++ b/src/ezdxf/document.py
@@ -10,6 +10,8 @@ import io
 import base64
 import logging
 from itertools import chain
+
+from ezdxf.layouts import Modelspace
 from ezdxf.lldxf import const
 from ezdxf.lldxf.const import (
     BLK_XREF, BLK_EXTERNAL, DXF13, DXF14, DXF2000, DXF2007, DXF12, DXF2013,
@@ -670,7 +672,7 @@ class Drawing:
         """
         self._dimension_renderer = renderer
 
-    def modelspace(self) -> 'Layout':
+    def modelspace(self) -> 'Modelspace':
         """ Returns the modelspace layout, displayed as ``'Model'`` tab in CAD
         applications, defined by block record named ``'*Model_Space'``.
         """

--- a/src/ezdxf/entities/geodata.py
+++ b/src/ezdxf/entities/geodata.py
@@ -355,9 +355,10 @@ class GeoData(DXFObject):
 
         source = self.dxf.design_point  # in CAD WCS coordinates
         target = self.dxf.reference_point  # in the CRS of the geodata
+        north = self.dxf.north_direction
 
         # -pi/2 because north is at pi/2 so if the given north is at pi/2, no rotation is necessary
-        theta = -(math.atan2(self.dxf.north_direction.y, self.dxf.north_direction.x) - math.pi / 2)
+        theta = -(math.atan2(north.y, north.x) - math.pi / 2)
 
         transformation = (Matrix44.translate(-source.x, -source.y, 0) @
                           Matrix44.scale(self.dxf.horizontal_unit_scale, self.dxf.vertical_unit_scale, 1) @

--- a/src/ezdxf/entities/geodata.py
+++ b/src/ezdxf/entities/geodata.py
@@ -1,13 +1,18 @@
 # Copyright (c) 2019-2020, Manfred Moitzi
 # License: MIT-License
 # Created: 2019-03-11
+import math
+import re
 from typing import TYPE_CHECKING, List, Sequence, Iterable
+from typing import Tuple, Optional
+from xml.etree import ElementTree
+
 from ezdxf.lldxf import validator
-from ezdxf.lldxf.const import (
-    SUBCLASS_MARKER, DXFStructureError, DXF2010, DXFTypeError,
-)
 from ezdxf.lldxf.attributes import (
     DXFAttributes, DefSubclass, DXFAttr, XType, RETURN_DEFAULT,
+)
+from ezdxf.lldxf.const import (
+    SUBCLASS_MARKER, DXFStructureError, DXF2010, DXFTypeError,
 )
 from ezdxf.lldxf.packedtags import VertexArray
 from ezdxf.lldxf.tags import Tags, DXFTag
@@ -16,11 +21,13 @@ from .dxfentity import base_class, SubclassProcessor
 from .dxfobj import DXFObject
 from .factory import register_entity
 from .mtext import split_mtext_string
+from .. import units
+from ..math import Matrix44
 
 if TYPE_CHECKING:
     from ezdxf.eztypes import TagWriter, DXFNamespace
 
-__all__ = ['GeoData']
+__all__ = ['GeoData', 'MeshVertices', 'InvalidGeoDataException']
 
 acdb_geo_data = DefSubclass('AcDbGeoData', {
     # 1 = R2009, but this release has no DXF version,
@@ -123,6 +130,10 @@ acdb_geo_data = DefSubclass('AcDbGeoData', {
     # face index 99 repeat, faces_count
 
 })
+
+
+class InvalidGeoDataException(Exception):
+    pass
 
 
 class MeshVertices(VertexArray):
@@ -252,3 +263,109 @@ class GeoData(DXFObject):
         while len(chunks) > 1:
             tagwriter.write_tag2(303, chunks.pop(0))
         tagwriter.write_tag2(301, chunks[0])
+
+    def decoded_units(self) -> Tuple[Optional[str], Optional[str]]:
+        return units.decode(self.dxf.horizontal_units), units.decode(self.dxf.vertical_units)
+
+    def get_crs(self) -> Tuple[int, bool]:
+        """
+
+        The EPSG number is stored in a tag like:
+
+        <Alias id="27700" type="CoordinateSystem">
+          <ObjectId>OSGB1936.NationalGrid</ObjectId>
+          <Namespace>EPSG Code</Namespace>
+        </Alias>
+
+        The axis-ordering is stored in a tag like:
+
+        <Axis uom="METER">
+          <CoordinateSystemAxis>
+            <AxisOrder>1</AxisOrder>
+            <AxisName>Easting</AxisName>
+            <AxisAbbreviation>E</AxisAbbreviation>
+            <AxisDirection>east</AxisDirection>
+          </CoordinateSystemAxis>
+          <CoordinateSystemAxis>
+            <AxisOrder>2</AxisOrder>
+            <AxisName>Northing</AxisName>
+            <AxisAbbreviation>N</AxisAbbreviation>
+            <AxisDirection>north</AxisDirection>
+          </CoordinateSystemAxis>
+        </Axis>
+
+        """
+        definition = self.coordinate_system_definition
+        try:
+            # remove namespaces so that tags can be searched without prefixing their namespace
+            definition = _remove_xml_namespaces(definition)
+            root = ElementTree.fromstring(definition)
+        except ElementTree.ParseError:
+            raise InvalidGeoDataException('failed to parse coordinate_system_definition as xml')
+
+        crs = None
+        for alias in root.findall('Alias'):
+            if alias.get('type') == 'CoordinateSystem' and alias.find('Namespace').text == 'EPSG Code':
+                try:
+                    crs = int(alias.get('id'))
+                except ValueError:
+                    raise InvalidGeoDataException(f'invalid epsg number: {alias.get("id")}')
+                break
+
+        xy_ordering = None
+        for axis in root.findall('.//CoordinateSystemAxis'):
+            if axis.find('AxisOrder').text == '1':
+                first_axis = axis.find('AxisAbbreviation').text
+                if first_axis in ('E', 'W'):
+                    xy_ordering = True
+                elif first_axis in ('N', 'S'):
+                    xy_ordering = False
+                else:
+                    raise InvalidGeoDataException(f'unknown first axis: {first_axis}')
+                break
+
+        if crs is None:
+            raise InvalidGeoDataException('no EPSG code associated with CRS')
+        elif xy_ordering is None:
+            raise InvalidGeoDataException('could not determine axis ordering')
+        else:
+            return crs, xy_ordering
+
+    def get_crs_transformation(self, *, no_checks: bool = False) -> Tuple[Matrix44, int]:
+        epsg, xy_ordering = self.get_crs()
+
+        if not no_checks:
+            if (self.dxf.coordinate_type != GeoData.LOCAL_GRID or
+                    self.dxf.scale_estimation_method != GeoData.NONE or
+                    not math.isclose(self.dxf.user_scale_factor, 1.0) or
+                    self.dxf.sea_level_correction != 0 or
+                    not math.isclose(self.dxf.sea_level_elevation, 0) or
+                    self.faces or
+                    not self.dxf.up_direction.isclose((0, 0, 1)) or
+                    self.dxf.observation_coverage_tag != '' or
+                    self.dxf.observation_from_tag != '' or
+                    self.dxf.observation_to_tag != '' or
+                    not xy_ordering):
+                raise InvalidGeoDataException(
+                    f'Untested geodata configuration: '
+                    f'{self.dxf.all_existing_dxf_attribs()}.\n'
+                    f'You can try with no_checks=True but the '
+                    f'results may be incorrect.'
+                )
+
+        source = self.dxf.design_point  # in CAD WCS coordinates
+        target = self.dxf.reference_point  # in the CRS of the geodata
+
+        # -pi/2 because north is at pi/2 so if the given north is at pi/2, no rotation is necessary
+        theta = -(math.atan2(self.dxf.north_direction.y, self.dxf.north_direction.x) - math.pi / 2)
+
+        transformation = (Matrix44.translate(-source.x, -source.y, 0) @
+                          Matrix44.scale(self.dxf.horizontal_unit_scale, self.dxf.vertical_unit_scale, 1) @
+                          Matrix44.z_rotate(theta) @
+                          Matrix44.translate(target.x, target.y, 0))
+
+        return transformation, epsg
+
+
+def _remove_xml_namespaces(xml_string: str) -> str:
+    return re.sub('xmlns=\"[^\"]*\"', '', xml_string)

--- a/tests/test_01_dxf_entities/houses_of_parliament_georeferenced.dxf
+++ b/tests/test_01_dxf_entities/houses_of_parliament_georeferenced.dxf
@@ -1,0 +1,21166 @@
+  0
+SECTION
+  2
+HEADER
+  9
+$ACADVER
+  1
+AC1032
+  9
+$ACADMAINTVER
+ 90
+      155
+  9
+$DWGCODEPAGE
+  3
+ANSI_1252
+  9
+$LASTSAVEDBY
+  1
+xxxxxxx
+  9
+$REQUIREDVERSIONS
+160
+                 0
+  9
+$INSBASE
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$EXTMIN
+ 10
+-5709.247060655471
+ 20
+-791.1158899445182
+ 30
+0.0
+  9
+$EXTMAX
+ 10
+26949.46102454514
+ 20
+16140.02821701173
+ 30
+0.0
+  9
+$LIMMIN
+ 10
+0.0
+ 20
+0.0
+  9
+$LIMMAX
+ 10
+12.0
+ 20
+9.0
+  9
+$ORTHOMODE
+ 70
+     0
+  9
+$REGENMODE
+ 70
+     1
+  9
+$FILLMODE
+ 70
+     1
+  9
+$QTEXTMODE
+ 70
+     0
+  9
+$MIRRTEXT
+ 70
+     0
+  9
+$LTSCALE
+ 40
+1.0
+  9
+$ATTMODE
+ 70
+     1
+  9
+$TEXTSIZE
+ 40
+0.2
+  9
+$TRACEWID
+ 40
+0.05
+  9
+$TEXTSTYLE
+  7
+Standard
+  9
+$CLAYER
+  8
+0
+  9
+$CELTYPE
+  6
+ByLayer
+  9
+$CECOLOR
+ 62
+   256
+  9
+$CELTSCALE
+ 40
+1.0
+  9
+$DISPSILH
+ 70
+     0
+  9
+$DIMSCALE
+ 40
+1.0
+  9
+$DIMASZ
+ 40
+0.18
+  9
+$DIMEXO
+ 40
+0.0625
+  9
+$DIMDLI
+ 40
+0.38
+  9
+$DIMRND
+ 40
+0.0
+  9
+$DIMDLE
+ 40
+0.0
+  9
+$DIMEXE
+ 40
+0.18
+  9
+$DIMTP
+ 40
+0.0
+  9
+$DIMTM
+ 40
+0.0
+  9
+$DIMTXT
+ 40
+0.18
+  9
+$DIMCEN
+ 40
+0.09
+  9
+$DIMTSZ
+ 40
+0.0
+  9
+$DIMTOL
+ 70
+     0
+  9
+$DIMLIM
+ 70
+     0
+  9
+$DIMTIH
+ 70
+     1
+  9
+$DIMTOH
+ 70
+     1
+  9
+$DIMSE1
+ 70
+     0
+  9
+$DIMSE2
+ 70
+     0
+  9
+$DIMTAD
+ 70
+     0
+  9
+$DIMZIN
+ 70
+     0
+  9
+$DIMBLK
+  1
+
+  9
+$DIMASO
+ 70
+     1
+  9
+$DIMSHO
+ 70
+     1
+  9
+$DIMPOST
+  1
+
+  9
+$DIMAPOST
+  1
+
+  9
+$DIMALT
+ 70
+     0
+  9
+$DIMALTD
+ 70
+     2
+  9
+$DIMALTF
+ 40
+25.4
+  9
+$DIMLFAC
+ 40
+1.0
+  9
+$DIMTOFL
+ 70
+     0
+  9
+$DIMTVP
+ 40
+0.0
+  9
+$DIMTIX
+ 70
+     0
+  9
+$DIMSOXD
+ 70
+     0
+  9
+$DIMSAH
+ 70
+     0
+  9
+$DIMBLK1
+  1
+
+  9
+$DIMBLK2
+  1
+
+  9
+$DIMSTYLE
+  2
+Standard
+  9
+$DIMCLRD
+ 70
+     0
+  9
+$DIMCLRE
+ 70
+     0
+  9
+$DIMCLRT
+ 70
+     0
+  9
+$DIMTFAC
+ 40
+1.0
+  9
+$DIMGAP
+ 40
+0.09
+  9
+$DIMJUST
+ 70
+     0
+  9
+$DIMSD1
+ 70
+     0
+  9
+$DIMSD2
+ 70
+     0
+  9
+$DIMTOLJ
+ 70
+     1
+  9
+$DIMTZIN
+ 70
+     0
+  9
+$DIMALTZ
+ 70
+     0
+  9
+$DIMALTTZ
+ 70
+     0
+  9
+$DIMUPT
+ 70
+     0
+  9
+$DIMDEC
+ 70
+     4
+  9
+$DIMTDEC
+ 70
+     4
+  9
+$DIMALTU
+ 70
+     2
+  9
+$DIMALTTD
+ 70
+     2
+  9
+$DIMTXSTY
+  7
+Standard
+  9
+$DIMAUNIT
+ 70
+     0
+  9
+$DIMADEC
+ 70
+     0
+  9
+$DIMALTRND
+ 40
+0.0
+  9
+$DIMAZIN
+ 70
+     0
+  9
+$DIMDSEP
+ 70
+    46
+  9
+$DIMATFIT
+ 70
+     3
+  9
+$DIMFRAC
+ 70
+     0
+  9
+$DIMLDRBLK
+  1
+
+  9
+$DIMLUNIT
+ 70
+     2
+  9
+$DIMLWD
+ 70
+    -2
+  9
+$DIMLWE
+ 70
+    -2
+  9
+$DIMTMOVE
+ 70
+     0
+  9
+$DIMFXL
+ 40
+1.0
+  9
+$DIMFXLON
+ 70
+     0
+  9
+$DIMJOGANG
+ 40
+0.7853981633974483
+  9
+$DIMTFILL
+ 70
+     0
+  9
+$DIMTFILLCLR
+ 70
+     0
+  9
+$DIMARCSYM
+ 70
+     0
+  9
+$DIMLTYPE
+  6
+
+  9
+$DIMLTEX1
+  6
+
+  9
+$DIMLTEX2
+  6
+
+  9
+$DIMTXTDIRECTION
+ 70
+     0
+  9
+$LUNITS
+ 70
+     2
+  9
+$LUPREC
+ 70
+     4
+  9
+$SKETCHINC
+ 40
+0.1
+  9
+$FILLETRAD
+ 40
+0.0
+  9
+$AUNITS
+ 70
+     0
+  9
+$AUPREC
+ 70
+     0
+  9
+$MENU
+  1
+.
+  9
+$ELEVATION
+ 40
+0.0
+  9
+$PELEVATION
+ 40
+0.0
+  9
+$THICKNESS
+ 40
+0.0
+  9
+$LIMCHECK
+ 70
+     0
+  9
+$CHAMFERA
+ 40
+0.0
+  9
+$CHAMFERB
+ 40
+0.0
+  9
+$CHAMFERC
+ 40
+0.0
+  9
+$CHAMFERD
+ 40
+0.0
+  9
+$SKPOLY
+ 70
+     0
+  9
+$TDCREATE
+ 40
+2459009.535578704
+  9
+$TDUCREATE
+ 40
+2459009.493912037
+  9
+$TDUPDATE
+ 40
+2459086.675740741
+  9
+$TDUUPDATE
+ 40
+2459086.634074074
+  9
+$TDINDWG
+ 40
+0.0110648148
+  9
+$TDUSRTIMER
+ 40
+0.0110648148
+  9
+$USRTIMER
+ 70
+     1
+  9
+$ANGBASE
+ 50
+0.0
+  9
+$ANGDIR
+ 70
+     0
+  9
+$PDMODE
+ 70
+     0
+  9
+$PDSIZE
+ 40
+0.0
+  9
+$PLINEWID
+ 40
+0.0
+  9
+$SPLFRAME
+ 70
+     0
+  9
+$SPLINETYPE
+ 70
+     6
+  9
+$SPLINESEGS
+ 70
+     8
+  9
+$HANDSEED
+  5
+241
+  9
+$SURFTAB1
+ 70
+     6
+  9
+$SURFTAB2
+ 70
+     6
+  9
+$SURFTYPE
+ 70
+     6
+  9
+$SURFU
+ 70
+     6
+  9
+$SURFV
+ 70
+     6
+  9
+$UCSBASE
+  2
+
+  9
+$UCSNAME
+  2
+
+  9
+$UCSORG
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSXDIR
+ 10
+1.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSYDIR
+ 10
+0.0
+ 20
+1.0
+ 30
+0.0
+  9
+$UCSORTHOREF
+  2
+
+  9
+$UCSORTHOVIEW
+ 70
+     0
+  9
+$UCSORGTOP
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGBOTTOM
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGLEFT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGRIGHT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGFRONT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$UCSORGBACK
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSBASE
+  2
+
+  9
+$PUCSNAME
+  2
+
+  9
+$PUCSORG
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSXDIR
+ 10
+1.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSYDIR
+ 10
+0.0
+ 20
+1.0
+ 30
+0.0
+  9
+$PUCSORTHOREF
+  2
+
+  9
+$PUCSORTHOVIEW
+ 70
+     0
+  9
+$PUCSORGTOP
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGBOTTOM
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGLEFT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGRIGHT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGFRONT
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PUCSORGBACK
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$USERI1
+ 70
+     0
+  9
+$USERI2
+ 70
+     0
+  9
+$USERI3
+ 70
+     0
+  9
+$USERI4
+ 70
+     0
+  9
+$USERI5
+ 70
+     0
+  9
+$USERR1
+ 40
+0.0
+  9
+$USERR2
+ 40
+0.0
+  9
+$USERR3
+ 40
+0.0
+  9
+$USERR4
+ 40
+0.0
+  9
+$USERR5
+ 40
+0.0
+  9
+$WORLDVIEW
+ 70
+     1
+  9
+$SHADEDGE
+ 70
+     3
+  9
+$SHADEDIF
+ 70
+    70
+  9
+$TILEMODE
+ 70
+     1
+  9
+$MAXACTVP
+ 70
+    64
+  9
+$PINSBASE
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PLIMCHECK
+ 70
+     0
+  9
+$PEXTMIN
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PEXTMAX
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  9
+$PLIMMIN
+ 10
+0.0
+ 20
+0.0
+  9
+$PLIMMAX
+ 10
+12.0
+ 20
+9.0
+  9
+$UNITMODE
+ 70
+     0
+  9
+$VISRETAIN
+ 70
+     1
+  9
+$PLINEGEN
+ 70
+     0
+  9
+$PSLTSCALE
+ 70
+     1
+  9
+$TREEDEPTH
+ 70
+  3020
+  9
+$CMLSTYLE
+  2
+Standard
+  9
+$CMLJUST
+ 70
+     0
+  9
+$CMLSCALE
+ 40
+1.0
+  9
+$PROXYGRAPHICS
+ 70
+     1
+  9
+$MEASUREMENT
+ 70
+     0
+  9
+$CELWEIGHT
+370
+    -1
+  9
+$ENDCAPS
+280
+     0
+  9
+$JOINSTYLE
+280
+     0
+  9
+$LWDISPLAY
+290
+     0
+  9
+$INSUNITS
+ 70
+     1
+  9
+$HYPERLINKBASE
+  1
+
+  9
+$STYLESHEET
+  1
+
+  9
+$XEDIT
+290
+     1
+  9
+$CEPSNTYPE
+380
+     0
+  9
+$PSTYLEMODE
+290
+     1
+  9
+$FINGERPRINTGUID
+  2
+{145A3C05-5D5B-9A45-B4D3-17DBC5321152}
+  9
+$VERSIONGUID
+  2
+{B8D4FB5D-1090-2043-B043-E4BC11EDEEC9}
+  9
+$EXTNAMES
+290
+     1
+  9
+$PSVPSCALE
+ 40
+0.0
+  9
+$OLESTARTUP
+290
+     0
+  9
+$SORTENTS
+280
+   127
+  9
+$INDEXCTL
+280
+     0
+  9
+$HIDETEXT
+280
+     1
+  9
+$XCLIPFRAME
+280
+     2
+  9
+$HALOGAP
+280
+     0
+  9
+$OBSCOLOR
+ 70
+   257
+  9
+$OBSLTYPE
+280
+     0
+  9
+$INTERSECTIONDISPLAY
+280
+     0
+  9
+$INTERSECTIONCOLOR
+ 70
+   257
+  9
+$DIMASSOC
+280
+     2
+  9
+$PROJECTNAME
+  1
+
+  9
+$CAMERADISPLAY
+290
+     0
+  9
+$LENSLENGTH
+ 40
+50.0
+  9
+$CAMERAHEIGHT
+ 40
+0.0
+  9
+$STEPSPERSEC
+ 40
+2.0
+  9
+$STEPSIZE
+ 40
+6.0
+  9
+$3DDWFPREC
+ 40
+2.0
+  9
+$PSOLWIDTH
+ 40
+0.25
+  9
+$PSOLHEIGHT
+ 40
+4.0
+  9
+$LOFTANG1
+ 40
+1.570796326794896
+  9
+$LOFTANG2
+ 40
+1.570796326794896
+  9
+$LOFTMAG1
+ 40
+0.0
+  9
+$LOFTMAG2
+ 40
+0.0
+  9
+$LOFTPARAM
+ 70
+     7
+  9
+$LOFTNORMALS
+280
+     1
+  9
+$LATITUDE
+ 40
+51.4982538676456
+  9
+$LONGITUDE
+ 40
+-0.1255735459345453
+  9
+$NORTHDIRECTION
+ 40
+-0.5585053606381855
+  9
+$TIMEZONE
+ 70
+     0
+  9
+$LIGHTGLYPHDISPLAY
+280
+     1
+  9
+$TILEMODELIGHTSYNCH
+280
+     1
+  9
+$CMATERIAL
+347
+96
+  9
+$SOLIDHIST
+280
+     0
+  9
+$SHOWHIST
+280
+     1
+  9
+$DWFFRAME
+280
+     2
+  9
+$DGNFRAME
+280
+     0
+  9
+$REALWORLDSCALE
+290
+     1
+  9
+$INTERFERECOLOR
+ 62
+     1
+  9
+$INTERFEREOBJVS
+345
+A3
+  9
+$INTERFEREVPVS
+346
+A0
+  9
+$CSHADOW
+280
+     0
+  9
+$SHADOWPLANELOCATION
+ 40
+0.0
+  0
+ENDSEC
+  0
+SECTION
+  2
+CLASSES
+  0
+CLASS
+  1
+ACDBDICTIONARYWDFLT
+  2
+AcDbDictionaryWithDefault
+  3
+ObjectDBX Classes
+ 90
+        0
+ 91
+        1
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+DICTIONARYVAR
+  2
+AcDbDictionaryVar
+  3
+ObjectDBX Classes
+ 90
+        0
+ 91
+       13
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+TABLESTYLE
+  2
+AcDbTableStyle
+  3
+ObjectDBX Classes
+ 90
+     4095
+ 91
+        1
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+MATERIAL
+  2
+AcDbMaterial
+  3
+ObjectDBX Classes
+ 90
+     1153
+ 91
+        3
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+VISUALSTYLE
+  2
+AcDbVisualStyle
+  3
+ObjectDBX Classes
+ 90
+     4095
+ 91
+       24
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+SCALE
+  2
+AcDbScale
+  3
+ObjectDBX Classes
+ 90
+     1153
+ 91
+       33
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+MLEADERSTYLE
+  2
+AcDbMLeaderStyle
+  3
+ACDB_MLEADERSTYLE_CLASS
+ 90
+     4095
+ 91
+        2
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+CELLSTYLEMAP
+  2
+AcDbCellStyleMap
+  3
+ObjectDBX Classes
+ 90
+     1152
+ 91
+        2
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+EXACXREFPANELOBJECT
+  2
+ExAcXREFPanelObject
+  3
+EXAC_ESW
+ 90
+     1025
+ 91
+        0
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+NPOCOLLECTION
+  2
+AcDbImpNonPersistentObjectsCollection
+  3
+ObjectDBX Classes
+ 90
+     1153
+ 91
+        0
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+LAYER_INDEX
+  2
+AcDbLayerIndex
+  3
+ObjectDBX Classes
+ 90
+        0
+ 91
+        0
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+SPATIAL_INDEX
+  2
+AcDbSpatialIndex
+  3
+ObjectDBX Classes
+ 90
+        0
+ 91
+        0
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+IDBUFFER
+  2
+AcDbIdBuffer
+  3
+ObjectDBX Classes
+ 90
+        0
+ 91
+        0
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+ACDBSECTIONVIEWSTYLE
+  2
+AcDbSectionViewStyle
+  3
+ObjectDBX Classes
+ 90
+     1025
+ 91
+        1
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+ACDBDETAILVIEWSTYLE
+  2
+AcDbDetailViewStyle
+  3
+ObjectDBX Classes
+ 90
+     1025
+ 91
+        1
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+GEODATA
+  2
+AcDbGeoData
+  3
+ObjectDBX Classes
+ 90
+     4095
+ 91
+        4
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+AcGeoBackupObject
+  2
+AcGeoBackupObject
+  3
+AcGeoLocationUI
+ 90
+     1024
+ 91
+        1
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+SUN
+  2
+AcDbSun
+  3
+SCENEOE
+ 90
+     1153
+ 91
+        1
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+GEOMAPIMAGE
+  2
+AcDbGeoMap
+  3
+AcGeolocationObj
+ 90
+        1
+ 91
+        0
+280
+     0
+281
+     1
+  0
+CLASS
+  1
+AcDbGeoMapDef
+  2
+AcDbGeoMapDef
+  3
+AcGeolocationObj
+ 90
+     1024
+ 91
+        0
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+RASTERVARIABLES
+  2
+AcDbRasterVariables
+  3
+ISM
+ 90
+        0
+ 91
+        1
+280
+     0
+281
+     0
+  0
+CLASS
+  1
+SORTENTSTABLE
+  2
+AcDbSortentsTable
+  3
+ObjectDBX Classes
+ 90
+        0
+ 91
+        1
+280
+     0
+281
+     0
+  0
+ENDSEC
+  0
+SECTION
+  2
+TABLES
+  0
+TABLE
+  2
+VPORT
+  5
+8
+330
+0
+100
+AcDbSymbolTable
+ 70
+     1
+  0
+VPORT
+  5
+94
+102
+{ACAD_XDICTIONARY
+360
+21F
+102
+}
+330
+8
+100
+AcDbSymbolTableRecord
+100
+AcDbViewportTableRecord
+  2
+*Active
+ 70
+     0
+ 10
+0.0
+ 20
+0.0
+ 11
+1.0
+ 21
+1.0
+ 12
+23968.00131732249
+ 22
+10175.63697492285
+ 13
+0.0
+ 23
+0.0
+ 14
+0.5
+ 24
+0.5
+ 15
+0.5
+ 25
+0.5
+ 16
+0.0
+ 26
+0.0
+ 36
+1.0
+ 17
+0.0
+ 27
+0.0
+ 37
+0.0
+ 40
+12978.47128840767
+ 41
+1.461910519951632
+ 42
+50.0
+ 43
+0.0
+ 44
+0.0
+ 50
+0.0
+ 51
+0.0
+ 71
+     0
+ 72
+  1000
+ 73
+     1
+ 74
+     3
+ 75
+     0
+ 76
+     1
+ 77
+     0
+ 78
+     0
+281
+     0
+ 65
+     1
+110
+0.0
+120
+0.0
+130
+0.0
+111
+1.0
+121
+0.0
+131
+0.0
+112
+0.0
+122
+1.0
+132
+0.0
+ 79
+     0
+146
+0.0
+348
+9F
+ 60
+     3
+ 61
+     5
+292
+     1
+282
+     1
+141
+0.0
+142
+0.0
+ 63
+   250
+421
+  3355443
+361
+21E
+1001
+ACAD_NAV_VCDISPLAY
+1070
+     3
+  0
+ENDTAB
+  0
+TABLE
+  2
+LTYPE
+  5
+5
+330
+0
+100
+AcDbSymbolTable
+ 70
+     1
+  0
+LTYPE
+  5
+14
+330
+5
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+ByBlock
+ 70
+     0
+  3
+
+ 72
+    65
+ 73
+     0
+ 40
+0.0
+  0
+LTYPE
+  5
+15
+330
+5
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+ByLayer
+ 70
+     0
+  3
+
+ 72
+    65
+ 73
+     0
+ 40
+0.0
+  0
+LTYPE
+  5
+16
+330
+5
+100
+AcDbSymbolTableRecord
+100
+AcDbLinetypeTableRecord
+  2
+Continuous
+ 70
+     0
+  3
+Solid line
+ 72
+    65
+ 73
+     0
+ 40
+0.0
+  0
+ENDTAB
+  0
+TABLE
+  2
+LAYER
+  5
+2
+102
+{ACAD_XDICTIONARY
+360
+18E
+102
+}
+330
+0
+100
+AcDbSymbolTable
+ 70
+     1
+  0
+LAYER
+  5
+10
+102
+{ACAD_XDICTIONARY
+360
+E6
+102
+}
+330
+2
+100
+AcDbSymbolTableRecord
+100
+AcDbLayerTableRecord
+  2
+0
+ 70
+     0
+ 62
+     7
+  6
+Continuous
+370
+    -3
+390
+F
+347
+98
+348
+0
+  0
+ENDTAB
+  0
+TABLE
+  2
+STYLE
+  5
+3
+330
+0
+100
+AcDbSymbolTable
+ 70
+     2
+  0
+STYLE
+  5
+11
+330
+3
+100
+AcDbSymbolTableRecord
+100
+AcDbTextStyleTableRecord
+  2
+Standard
+ 70
+     0
+ 40
+0.0
+ 41
+1.0
+ 50
+0.0
+ 71
+     0
+ 42
+0.2
+  3
+arial.ttf
+  4
+
+1001
+ACAD
+1000
+Arial
+1071
+       34
+  0
+STYLE
+  5
+DC
+330
+3
+100
+AcDbSymbolTableRecord
+100
+AcDbTextStyleTableRecord
+  2
+Annotative
+ 70
+     0
+ 40
+0.0
+ 41
+1.0
+ 50
+0.0
+ 71
+     0
+ 42
+0.2
+  3
+arial.ttf
+  4
+
+1001
+AcadAnnotative
+1000
+AnnotativeData
+1002
+{
+1070
+     1
+1070
+     1
+1002
+}
+1001
+ACAD
+1000
+Arial
+1071
+       34
+  0
+ENDTAB
+  0
+TABLE
+  2
+VIEW
+  5
+6
+330
+0
+100
+AcDbSymbolTable
+ 70
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+UCS
+  5
+7
+330
+0
+100
+AcDbSymbolTable
+ 70
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+APPID
+  5
+9
+330
+0
+100
+AcDbSymbolTable
+ 70
+     7
+  0
+APPID
+  5
+12
+330
+9
+100
+AcDbSymbolTableRecord
+100
+AcDbRegAppTableRecord
+  2
+ACAD
+ 70
+     0
+  0
+APPID
+  5
+DD
+330
+9
+100
+AcDbSymbolTableRecord
+100
+AcDbRegAppTableRecord
+  2
+AcadAnnoPO
+ 70
+     0
+  0
+APPID
+  5
+DE
+330
+9
+100
+AcDbSymbolTableRecord
+100
+AcDbRegAppTableRecord
+  2
+AcadAnnotative
+ 70
+     0
+  0
+APPID
+  5
+DF
+330
+9
+100
+AcDbSymbolTableRecord
+100
+AcDbRegAppTableRecord
+  2
+ACAD_DSTYLE_DIMJAG
+ 70
+     0
+  0
+APPID
+  5
+E0
+330
+9
+100
+AcDbSymbolTableRecord
+100
+AcDbRegAppTableRecord
+  2
+ACAD_DSTYLE_DIMTALN
+ 70
+     0
+  0
+APPID
+  5
+107
+330
+9
+100
+AcDbSymbolTableRecord
+100
+AcDbRegAppTableRecord
+  2
+ACAD_MLEADERVER
+ 70
+     0
+  0
+APPID
+  5
+1A6
+330
+9
+100
+AcDbSymbolTableRecord
+100
+AcDbRegAppTableRecord
+  2
+ACAD_NAV_VCDISPLAY
+ 70
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+DIMSTYLE
+  5
+A
+330
+0
+100
+AcDbSymbolTable
+ 70
+     2
+100
+AcDbDimStyleTable
+ 71
+     2
+340
+27
+340
+E1
+  0
+DIMSTYLE
+105
+27
+330
+A
+100
+AcDbSymbolTableRecord
+100
+AcDbDimStyleTableRecord
+  2
+Standard
+ 70
+     0
+340
+11
+  0
+DIMSTYLE
+105
+E1
+330
+A
+100
+AcDbSymbolTableRecord
+100
+AcDbDimStyleTableRecord
+  2
+Annotative
+ 70
+     0
+ 40
+0.0
+340
+11
+1001
+AcadAnnotative
+1000
+AnnotativeData
+1002
+{
+1070
+     1
+1070
+     1
+1002
+}
+1001
+ACAD_DSTYLE_DIMJAG
+1070
+   388
+1040
+1.5
+1001
+ACAD_DSTYLE_DIMTALN
+1070
+   392
+1070
+     0
+  0
+ENDTAB
+  0
+TABLE
+  2
+BLOCK_RECORD
+  5
+1
+330
+0
+100
+AcDbSymbolTable
+ 70
+     1
+  0
+BLOCK_RECORD
+  5
+1F
+102
+{ACAD_XDICTIONARY
+360
+15D
+102
+}
+330
+1
+100
+AcDbSymbolTableRecord
+100
+AcDbBlockTableRecord
+  2
+*Model_Space
+340
+22
+ 70
+     0
+280
+     1
+281
+     0
+  0
+BLOCK_RECORD
+  5
+58
+330
+1
+100
+AcDbSymbolTableRecord
+100
+AcDbBlockTableRecord
+  2
+*Paper_Space
+340
+59
+ 70
+     0
+280
+     1
+281
+     0
+  0
+BLOCK_RECORD
+  5
+5D
+330
+1
+100
+AcDbSymbolTableRecord
+100
+AcDbBlockTableRecord
+  2
+*Paper_Space0
+340
+5E
+ 70
+     0
+280
+     1
+281
+     0
+  0
+ENDTAB
+  0
+ENDSEC
+  0
+SECTION
+  2
+BLOCKS
+  0
+BLOCK
+  5
+20
+330
+1F
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockBegin
+  2
+*Model_Space
+ 70
+     0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+*Model_Space
+  1
+
+  0
+ENDBLK
+  5
+21
+330
+1F
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockEnd
+  0
+BLOCK
+  5
+5A
+330
+58
+100
+AcDbEntity
+ 67
+     1
+  8
+0
+100
+AcDbBlockBegin
+  2
+*Paper_Space
+ 70
+     0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+*Paper_Space
+  1
+
+  0
+ENDBLK
+  5
+5B
+330
+58
+100
+AcDbEntity
+ 67
+     1
+  8
+0
+100
+AcDbBlockEnd
+  0
+BLOCK
+  5
+5F
+330
+5D
+100
+AcDbEntity
+ 67
+     1
+  8
+0
+100
+AcDbBlockBegin
+  2
+*Paper_Space0
+ 70
+     0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+*Paper_Space0
+  1
+
+  0
+ENDBLK
+  5
+60
+330
+5D
+100
+AcDbEntity
+ 67
+     1
+  8
+0
+100
+AcDbBlockEnd
+  0
+ENDSEC
+  0
+SECTION
+  2
+ENTITIES
+  0
+LWPOLYLINE
+  5
+23C
+330
+1F
+100
+AcDbEntity
+  8
+0
+100
+AcDbPolyline
+ 90
+       16
+ 70
+     0
+ 43
+0.0
+ 10
+23448.14039573381
+ 20
+4967.0957105509
+ 10
+26949.46102454514
+ 20
+6582.01138472493
+ 10
+22478.68177662527
+ 20
+16140.02821701173
+ 10
+20626.05914035759
+ 20
+15273.46070810409
+ 10
+20244.82577706715
+ 20
+16088.49421821416
+ 10
+19253.94198219047
+ 20
+15625.00657376158
+ 10
+19615.05054030334
+ 20
+14771.08497820483
+ 10
+19980.85087457081
+ 20
+14925.7755633263
+ 10
+20806.66302642081
+ 20
+13081.78614099396
+ 10
+17688.58783328069
+ 20
+12119.78449254839
+ 10
+19170.63591439309
+ 20
+9378.079784747999
+ 10
+19757.68094435564
+ 20
+9560.860106015089
+ 10
+20001.35528691802
+ 20
+8778.238592172776
+ 10
+21297.15571861117
+ 20
+9181.694557412818
+ 10
+21494.59282762776
+ 20
+9253.791873040398
+ 10
+23448.14039573381
+ 20
+4967.0957105509
+  0
+ENDSEC
+  0
+SECTION
+  2
+OBJECTS
+  0
+DICTIONARY
+  5
+C
+330
+0
+100
+AcDbDictionary
+281
+     1
+  3
+ACAD_CIP_PREVIOUS_PRODUCT_INFO
+350
+1A5
+  3
+ACAD_COLOR
+350
+73
+  3
+ACAD_DETAILVIEWSTYLE
+350
+1AB
+  3
+ACAD_GROUP
+350
+D
+  3
+ACAD_IMAGE_VARS
+350
+224
+  3
+ACAD_LAYOUT
+350
+1A
+  3
+ACAD_MATERIAL
+350
+72
+  3
+ACAD_MLEADERSTYLE
+350
+D7
+  3
+ACAD_MLINESTYLE
+350
+17
+  3
+ACAD_PLOTSETTINGS
+350
+19
+  3
+ACAD_PLOTSTYLENAME
+350
+E
+  3
+ACAD_SCALELIST
+350
+B6
+  3
+ACAD_SECTIONVIEWSTYLE
+350
+1A8
+  3
+ACAD_TABLESTYLE
+350
+86
+  3
+ACAD_VISUALSTYLE
+350
+99
+  3
+ACDB_RECOMPOSE_DATA
+350
+240
+  3
+AcDbVariableDictionary
+350
+66
+  0
+DICTIONARY
+  5
+21F
+330
+94
+100
+AcDbDictionary
+280
+     1
+281
+     1
+  3
+AcDbVariableDictionary
+360
+220
+  0
+SUN
+  5
+21E
+330
+94
+100
+AcDbSun
+ 90
+        1
+290
+     1
+ 63
+     7
+421
+ 16777215
+ 40
+1.0
+291
+     1
+ 91
+  2459114
+ 92
+ 54000000
+292
+     0
+ 70
+     0
+ 71
+   256
+280
+     1
+  0
+DICTIONARY
+  5
+18E
+330
+2
+100
+AcDbDictionary
+280
+     1
+281
+     1
+  3
+ACAD_LAYERSTATES
+360
+18F
+  0
+DICTIONARY
+  5
+E6
+330
+10
+100
+AcDbDictionary
+280
+     1
+281
+     1
+  0
+DICTIONARY
+  5
+15D
+330
+1F
+100
+AcDbDictionary
+280
+     1
+281
+     1
+  3
+ACAD_GEOGRAPHICDATA
+360
+23D
+  3
+ACAD_SORTENTS
+360
+225
+  0
+XRECORD
+  5
+1A5
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbXrecord
+280
+     1
+300
+ACD
+300
+2020
+300
+
+  0
+DICTIONARY
+  5
+73
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  0
+DICTIONARY
+  5
+1AB
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+Imperial24
+350
+1AC
+  0
+DICTIONARY
+  5
+D
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  0
+RASTERVARIABLES
+  5
+224
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbRasterVariables
+ 90
+        0
+ 70
+     1
+ 71
+     1
+ 72
+     5
+  0
+DICTIONARY
+  5
+1A
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+Layout1
+350
+59
+  3
+Layout2
+350
+5E
+  3
+Model
+350
+22
+  0
+DICTIONARY
+  5
+72
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+ByBlock
+350
+97
+  3
+ByLayer
+350
+96
+  3
+Global
+350
+98
+  0
+DICTIONARY
+  5
+D7
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+Annotative
+350
+E5
+  3
+Standard
+350
+D8
+  0
+DICTIONARY
+  5
+17
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+Standard
+350
+18
+  0
+DICTIONARY
+  5
+19
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  0
+ACDBDICTIONARYWDFLT
+  5
+E
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+Normal
+350
+F
+100
+AcDbDictionaryWithDefault
+340
+F
+  0
+DICTIONARY
+  5
+B6
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+A0
+350
+B7
+  3
+A1
+350
+124
+  3
+A2
+350
+125
+  3
+A3
+350
+126
+  3
+A4
+350
+127
+  3
+A5
+350
+128
+  3
+A6
+350
+129
+  3
+A7
+350
+12A
+  3
+A8
+350
+12B
+  3
+A9
+350
+12C
+  3
+B0
+350
+12D
+  3
+B1
+350
+12E
+  3
+B2
+350
+12F
+  3
+B3
+350
+130
+  3
+B4
+350
+131
+  3
+B5
+350
+132
+  3
+B6
+350
+133
+  3
+B7
+350
+134
+  3
+B8
+350
+135
+  3
+B9
+350
+136
+  3
+C0
+350
+137
+  3
+C1
+350
+138
+  3
+C2
+350
+139
+  3
+C3
+350
+13A
+  3
+C4
+350
+13B
+  3
+C5
+350
+13C
+  3
+C6
+350
+13D
+  3
+C7
+350
+13E
+  3
+C8
+350
+13F
+  3
+C9
+350
+140
+  3
+D0
+350
+141
+  3
+D1
+350
+142
+  3
+D2
+350
+143
+  0
+DICTIONARY
+  5
+1A8
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+Imperial24
+350
+1AA
+  0
+DICTIONARY
+  5
+86
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+Standard
+350
+87
+  0
+DICTIONARY
+  5
+99
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+2dWireframe
+350
+9F
+  3
+Basic
+350
+9E
+  3
+Brighten
+350
+A5
+  3
+ColorChange
+350
+A9
+  3
+Conceptual
+350
+A2
+  3
+Dim
+350
+A4
+  3
+EdgeColorOff
+350
+175
+  3
+Facepattern
+350
+A8
+  3
+Flat
+350
+9A
+  3
+FlatWithEdges
+350
+9B
+  3
+Gouraud
+350
+9C
+  3
+GouraudWithEdges
+350
+9D
+  3
+Hidden
+350
+A1
+  3
+JitterOff
+350
+173
+  3
+Linepattern
+350
+A7
+  3
+OverhangOff
+350
+174
+  3
+Realistic
+350
+A3
+  3
+Shaded
+350
+182
+  3
+Shaded with edges
+350
+181
+  3
+Shades of Gray
+350
+17E
+  3
+Sketchy
+350
+17F
+  3
+Thicken
+350
+A6
+  3
+Wireframe
+350
+A0
+  3
+X-Ray
+350
+180
+  0
+XRECORD
+  5
+240
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbXrecord
+280
+     1
+ 90
+        1
+330
+87
+  0
+DICTIONARY
+  5
+66
+102
+{ACAD_REACTORS
+330
+C
+102
+}
+330
+C
+100
+AcDbDictionary
+281
+     1
+  3
+CANNOSCALE
+350
+F0
+  3
+CMLEADERSTYLE
+350
+EF
+  3
+CTABLESTYLE
+350
+89
+  3
+CVIEWDETAILSTYLE
+350
+1B7
+  3
+CVIEWSECTIONSTYLE
+350
+1B8
+  3
+DIMASSOC
+350
+67
+  3
+HIDETEXT
+350
+6B
+  3
+LAYEREVAL
+350
+14D
+  3
+LAYERNOTIFY
+350
+14E
+  0
+DICTIONARY
+  5
+220
+102
+{ACAD_REACTORS
+330
+21F
+102
+}
+330
+21F
+100
+AcDbDictionary
+281
+     1
+  3
+GEOMAPMODE
+350
+23E
+  0
+DICTIONARY
+  5
+18F
+102
+{ACAD_REACTORS
+330
+18E
+102
+}
+330
+18E
+100
+AcDbDictionary
+281
+     1
+  0
+GEODATA
+  5
+23D
+102
+{ACAD_REACTORS
+330
+15D
+102
+}
+330
+15D
+100
+AcDbGeoData
+ 90
+        3
+330
+1F
+ 70
+     1
+ 10
+23448.14039573381
+ 20
+4967.0957105509
+ 30
+0.0
+ 11
+530207.5677217417
+ 21
+179366.7895852687
+ 31
+0.0
+ 40
+0.0254
+ 91
+        1
+ 41
+0.0254
+ 92
+        1
+210
+0.0
+220
+0.0
+230
+1.0
+ 12
+-0.5299192642332047
+ 22
+0.8480480961564261
+ 95
+        1
+141
+1.0
+294
+     0
+142
+0.0
+143
+6392485.388089918
+303
+<?xml version="1.0" encoding="UTF-16" standalone="no" ?>^J<Dictionary version="1.0" xmlns="http://www.osgeo.org/mapguide/coordinatesystem">^J^J  <ProjectedCoordinateSystem id="OSGB1936.NationalGrid">^J    <Name>OSGB1936.NationalGrid</Name>^J    <Descripti
+303
+on>OSGB 1936 British National Grid</Description>^J    <Authority>Ordnance Survey: OSTN15 NTv2 Transformation</Authority>^J    <AdditionalInformation>^J      <ParameterItem type="CsMap">^J        <Key>CSQuadrantSimplified</Key>^J        <IntegerValue>1</In
+303
+tegerValue>^J      </ParameterItem>^J    </AdditionalInformation>^J    <DomainOfValidity>^J      <Extent>^J        <GeographicElement>^J          <GeographicBoundingBox>^J            <WestBoundLongitude>-9.8</WestBoundLongitude>^J            <EastBoundLongit
+303
+ude>3.48333333333333</EastBoundLongitude>^J            <SouthBoundLatitude>49.1666666666667</SouthBoundLatitude>^J            <NorthBoundLatitude>61.7166666666667</NorthBoundLatitude>^J          </GeographicBoundingBox>^J        </GeographicElement>^J    
+303
+  </Extent>^J    </DomainOfValidity>^J    <DatumId>OSGB1936</DatumId>^J    <Axis uom="METER">^J      <CoordinateSystemAxis>^J        <AxisOrder>1</AxisOrder>^J        <AxisName>Easting</AxisName>^J        <AxisAbbreviation>E</AxisAbbreviation>^J        <Axis
+303
+Direction>east</AxisDirection>^J      </CoordinateSystemAxis>^J      <CoordinateSystemAxis>^J        <AxisOrder>2</AxisOrder>^J        <AxisName>Northing</AxisName>^J        <AxisAbbreviation>N</AxisAbbreviation>^J        <AxisDirection>north</AxisDirectio
+303
+n>^J      </CoordinateSystemAxis>^J    </Axis>^J    <Conversion>^J      <Projection>^J        <OperationMethodId>Transverse Mercator</OperationMethodId>^J        <ParameterValue>^J          <OperationParameterId>Longitude of natural origin</OperationParamet
+303
+erId>^J          <Value uom="degree">-2</Value>^J        </ParameterValue>^J        <ParameterValue>^J          <OperationParameterId>Latitude of false origin</OperationParameterId>^J          <Value uom="degree">49</Value>^J        </ParameterValue>^J     
+303
+   <ParameterValue>^J          <OperationParameterId>Scaling factor for coord differences</OperationParameterId>^J          <Value uom="unity">0.9996012717</Value>^J        </ParameterValue>^J        <ParameterValue>^J          <OperationParameterId>False
+303
+ easting</OperationParameterId>^J          <Value uom="METER">400000</Value>^J        </ParameterValue>^J        <ParameterValue>^J          <OperationParameterId>False northing</OperationParameterId>^J          <Value uom="METER">-100000</Value>^J        
+303
+</ParameterValue>^J      </Projection>^J    </Conversion>^J  </ProjectedCoordinateSystem>^J^J  <Alias id="27700" type="CoordinateSystem">^J    <ObjectId>OSGB1936.NationalGrid</ObjectId>^J    <Namespace>EPSG Code</Namespace>^J  </Alias>^J^J  <GeodeticDatum id="
+303
+OSGB1936">^J    <Name>OSGB1936</Name>^J    <Description>Ordnance Survey of Great Britain 1936</Description>^J    <Authority>Ordnance Survey: OSTN15 NTv2 Transofrmation</Authority>^J    <PrimeMeridianId>Greenwich</PrimeMeridianId>^J    <EllipsoidId>AIRY30<
+303
+/EllipsoidId>^J  </GeodeticDatum>^J^J  <Alias id="6277" type="Datum">^J    <ObjectId>OSGB1936</ObjectId>^J    <Namespace>EPSG Code</Namespace>^J  </Alias>^J^J  <Ellipsoid id="AIRY30">^J    <Name>AIRY30</Name>^J    <Description>Airy, 1830</Description>^J    <Aut
+303
+hority>US Defense Mapping Agency, TR-8350.2-B, December 1987</Authority>^J    <SemiMajorAxis uom="meter">6377563.396</SemiMajorAxis>^J    <SecondDefiningParameter>^J      <SemiMinorAxis uom="meter">6356256.909</SemiMinorAxis>^J    </SecondDefiningParamet
+303
+er>^J  </Ellipsoid>^J^J  <Alias id="7001" type="Ellipsoid">^J    <ObjectId>AIRY30</ObjectId>^J    <Namespace>EPSG Code</Namespace>^J  </Alias>^J^J  <Transformation id="OSGB1936_to_ETRS89">^J    <Name>OSGB1936_to_ETRS89</Name>^J    <Description>OSGB 1936 to ETR
+303
+S89, via OSTN15 NTv2</Description>^J    <Authority>Ordnance Survey: OSTN15 NTv2 Transformation</Authority>^J    <AdditionalInformation>^J      <ParameterItem type="CsMap">^J        <Key>TransformationGridFileFallback</Key>^J        <StringValue>OSGB-7P_to
+303
+_WGS84</StringValue>^J      </ParameterItem>^J    </AdditionalInformation>^J    <DomainOfValidity>^J      <Extent>^J        <GeographicElement>^J          <GeographicBoundingBox>^J            <WestBoundLongitude>9</WestBoundLongitude>^J            <EastBound
+303
+Longitude>2</EastBoundLongitude>^J            <SouthBoundLatitude>49</SouthBoundLatitude>^J            <NorthBoundLatitude>61</NorthBoundLatitude>^J          </GeographicBoundingBox>^J        </GeographicElement>^J      </Extent>^J    </DomainOfValidity>^J 
+303
+   <CoordinateOperationAccuracy>^J      <Accuracy uom="meter">1</Accuracy>^J    </CoordinateOperationAccuracy>^J    <SourceDatumId>OSGB1936</SourceDatumId>^J    <TargetDatumId>ETRS89</TargetDatumId>^J    <IsReversible>true</IsReversible>^J    <OperationMet
+303
+hodGroup>^J      <OperationMethod>^J        <OperationMethodId>NTv2</OperationMethodId>^J        <ParameterValue>^J          <OperationParameterId>Latitude and longitude difference file</OperationParameterId>^J          <ValueGridFile direction="forward">
+303
+.\UK\OSTN15_NTv2_OSGBtoETRS.gsb</ValueGridFile>^J        </ParameterValue>^J      </OperationMethod>^J    </OperationMethodGroup>^J  </Transformation>^J^J  <Transformation id="ETRS89_to_WGS84">^J    <Name>ETRS89_to_WGS84</Name>^J    <Description>ETRS89 (ETRF
+303
+89), used for EUREF89 System</Description>^J    <Authority>Norwegian Geodetic Institute geodetic publication 1990:1</Authority>^J    <CoordinateOperationAccuracy>^J      <Accuracy uom="meter">8</Accuracy>^J    </CoordinateOperationAccuracy>^J    <SourceDa
+303
+tumId>ETRS89</SourceDatumId>^J    <TargetDatumId>WGS84</TargetDatumId>^J    <IsReversible>true</IsReversible>^J    <OperationMethod>^J      <OperationMethodId>Molodensky</OperationMethodId>^J      <ParameterValue>^J        <OperationParameterId>X-axis tran
+303
+slation</OperationParameterId>^J        <Value uom="meter">0</Value>^J      </ParameterValue>^J      <ParameterValue>^J        <OperationParameterId>Y-axis translation</OperationParameterId>^J        <Value uom="meter">0</Value>^J      </ParameterValue>^J  
+303
+    <ParameterValue>^J        <OperationParameterId>Z-axis translation</OperationParameterId>^J        <Value uom="meter">0</Value>^J      </ParameterValue>^J    </OperationMethod>^J  </Transformation>^J^J  <TransformationPath id="OSGB1936_to_WGS84">^J    <N
+303
+ame>OSGB1936_to_WGS84</Name>^J    <Description>Ordnance Survey of Great Britain 1936</Description>^J    <Authority>Autodesk</Authority>^J    <SourceDatumId>OSGB1936</SourceDatumId>^J    <TargetDatumId>WGS84</TargetDatumId>^J    <TransformationOperationGro
+303
+up>^J      <TransformationOperation>^J        <TransformationId>OSGB1936_to_ETRS89</TransformationId>^J        <Direction>forward</Direction>^J      </TransformationOperation>^J      <TransformationOperation>^J        <TransformationId>ETRS89_to_WGS84</Tra
+301
+nsformationId>^J        <Direction>forward</Direction>^J      </TransformationOperation>^J    </TransformationOperationGroup>^J  </TransformationPath>^J^J</Dictionary>^J
+302
+<georss:point>51.4983 -0.1256</georss:point>
+305
+
+306
+
+307
+
+ 93
+     1000
+ 13
+-941.2195533585036
+ 23
+-81473.76654058854
+ 14
+-7.488011992496045
+ 24
+49.0367600882485
+ 13
+800941.2195533585
+ 23
+-81473.76654058854
+ 14
+3.485400854216483
+ 24
+49.03692307558787
+ 13
+800941.2195533585
+ 23
+1315035.562193524
+ 14
+5.543268813316282
+ 24
+61.50733800521924
+ 13
+-941.2195533585036
+ 23
+1316432.071522258
+ 14
+-9.550104815485159
+ 24
+61.51952506301171
+ 13
+398783.9624550115
+ 23
+617479.1524908346
+ 14
+-2.02078927062393
+ 24
+55.45117364687953
+ 13
+400000.0
+ 23
+153007.5492304006
+ 14
+-2.001376605778782
+ 24
+51.2762095321127
+ 13
+399592.4518372825
+ 23
+1081717.682451074
+ 14
+-2.009002977206251
+ 24
+59.62118165897947
+ 13
+0.0
+ 23
+0.0
+ 14
+-7.557207274920616
+ 24
+49.76680680565131
+ 13
+82218.92652382416
+ 23
+384412.9570538254
+ 14
+-6.76689707293288
+ 24
+53.26124878844846
+ 13
+245935.6385908095
+ 23
+-43583.47290129726
+ 14
+-4.128583235323036
+ 24
+49.48864393887364
+ 13
+325827.599923375
+ 23
+385050.7512506271
+ 14
+-3.115897234009212
+ 24
+53.3571272677184
+ 13
+729183.0329701335
+ 23
+386106.7799660896
+ 14
+2.936019623935432
+ 24
+53.26961634980958
+ 13
+659123.8533181194
+ 23
+136058.4771326325
+ 14
+1.697096263706802
+ 24
+51.06533578395724
+ 13
+171637.3670470429
+ 23
+173306.6170756334
+ 14
+-5.285385035544544
+ 24
+51.41268123417301
+ 13
+527338.0595067237
+ 23
+449463.3877670714
+ 14
+-0.0622719809298194
+ 24
+53.92567550995376
+ 13
+728265.958779063
+ 23
+736387.8396181108
+ 14
+3.320392829019501
+ 24
+56.40540017787081
+ 13
+695605.1461470676
+ 23
+1034377.560363655
+ 14
+3.160593403438514
+ 24
+59.09345020128216
+ 13
+501275.0690203584
+ 23
+849420.6292466513
+ 14
+-0.3106468605854711
+ 24
+57.52362395830399
+ 13
+186341.8868178078
+ 23
+849969.0975824384
+ 14
+-5.566559595475731
+ 24
+57.48940180062265
+ 13
+143336.3677494356
+ 23
+1103530.759279166
+ 14
+-6.569494173358702
+ 24
+59.7375495505322
+ 13
+158985.8786461946
+ 23
+611665.577960691
+ 14
+-5.802254936780594
+ 24
+55.33976244122767
+ 13
+576562.2263380357
+ 23
+1239152.819008292
+ 14
+1.262968680389702
+ 24
+60.99528979066601
+ 13
+673245.949382257
+ 23
+561102.0608791366
+ 14
+2.257459375116692
+ 24
+54.86995538115573
+ 13
+537730.8966117572
+ 23
+269423.329275083
+ 14
+0.0186979810420332
+ 24
+52.30567716602126
+ 13
+343687.8687761008
+ 23
+780440.507741242
+ 14
+-2.926410335790586
+ 24
+56.91183928031956
+ 13
+556007.3433063063
+ 23
+686620.0397751647
+ 14
+0.5030595872218228
+ 24
+56.04702366277376
+ 13
+263018.3718900227
+ 23
+993401.6941109348
+ 14
+-4.372942518456984
+ 24
+58.80626933439866
+ 13
+539009.7513824624
+ 23
+1004341.230033656
+ 14
+0.4113751960030054
+ 24
+58.90387265436121
+ 13
+657870.4637849636
+ 23
+879456.9595766509
+ 14
+2.330106373823734
+ 24
+57.73070693377517
+ 13
+719758.9159465493
+ 23
+1185408.486369297
+ 14
+3.810571063471778
+ 24
+60.42549797974558
+ 13
+281013.285683332
+ 23
+526781.6475136946
+ 14
+-3.844367495410269
+ 24
+54.62211704266505
+ 13
+204214.7405975394
+ 23
+311596.1165029825
+ 14
+-4.896800740154692
+ 24
+52.66664186152016
+ 13
+393869.2624095276
+ 23
+940809.3660929969
+ 14
+-2.106460790216733
+ 24
+58.35571466202258
+ 13
+133770.0514180422
+ 23
+39163.79734316998
+ 14
+-5.731495698375751
+ 24
+50.19249321125232
+ 13
+31498.41669553748
+ 23
+140450.3748759077
+ 14
+-7.259497162602783
+ 24
+51.04485646055832
+ 13
+279226.1331862873
+ 23
+88991.50252812734
+ 14
+-3.711109837700011
+ 24
+50.68799305709786
+ 13
+411540.9069068211
+ 23
+-14700.87821853524
+ 14
+-1.841072022140003
+ 24
+49.76790682597106
+ 13
+605213.1053418586
+ 23
+-54082.0776331326
+ 14
+0.8259610579896426
+ 24
+49.37926235739239
+ 13
+525168.8358442871
+ 23
+77369.77183509507
+ 14
+-0.2333411803865219
+ 24
+50.58265291874418
+ 13
+132071.4327219422
+ 23
+971192.338596956
+ 14
+-6.606902156675457
+ 24
+58.54597872026897
+ 13
+274283.3069175161
+ 23
+1125740.114793145
+ 14
+-4.255745106668245
+ 24
+59.99719588471357
+ 13
+394007.6692526272
+ 23
+1266177.136703247
+ 14
+-2.113669884531112
+ 24
+61.27728994871605
+ 13
+199055.2292895701
+ 23
+1311124.803953895
+ 14
+-5.793719929641826
+ 24
+61.62822554407533
+ 13
+96762.30109751548
+ 23
+1227305.954609412
+ 14
+-7.580096512091816
+ 24
+60.81242913134772
+ 13
+669967.5789449472
+ 23
+267859.0864807635
+ 14
+1.953183474491305
+ 24
+52.24265802718666
+ 13
+715011.5533790097
+ 23
+17499.61735796452
+ 14
+2.392420741630612
+ 24
+49.97443870145
+ 13
+277606.5053787624
+ 23
+667304.3818069541
+ 14
+-3.958200620612239
+ 24
+55.88328049936321
+ 13
+407856.3410436049
+ 23
+283394.9929308658
+ 14
+-1.885826943698688
+ 24
+52.44847474587612
+ 13
+404297.0186036847
+ 23
+488509.108443574
+ 14
+-1.935492198462947
+ 24
+54.29219845956057
+ 13
+160991.980058541
+ 23
+484395.4875245221
+ 14
+-5.665921636211239
+ 24
+54.19944982312673
+ 13
+290714.7214838539
+ 23
+218237.0566859747
+ 14
+-3.588098070591719
+ 24
+51.85199860319075
+ 13
+77843.32174425834
+ 23
+258068.897937523
+ 14
+-6.708626592914637
+ 24
+52.12676444936094
+ 13
+598930.7519399711
+ 23
+1115166.907705397
+ 14
+1.552189393167854
+ 24
+59.87367213874542
+ 13
+512804.4502905275
+ 23
+571531.5255770868
+ 14
+-0.2369612474161371
+ 24
+55.02553966590632
+ 13
+681042.1946997236
+ 23
+1299890.627753609
+ 14
+3.27764910720552
+ 24
+61.47783474088797
+ 13
+473977.9634237162
+ 23
+1176284.084645754
+ 14
+-0.6566470247109803
+ 24
+60.46354031182956
+ 13
+175615.8511089516
+ 23
+730478.4671112807
+ 14
+-5.639053716264107
+ 24
+56.41303818586706
+ 13
+613317.4883990363
+ 23
+370178.6665134154
+ 14
+1.191260108619369
+ 24
+53.1859324745692
+ 13
+445695.6053986747
+ 23
+724134.1301044589
+ 14
+-1.26114716942974
+ 24
+56.40723889227241
+ 13
+295251.8779256979
+ 23
+883632.3443047348
+ 14
+-3.765500104698255
+ 24
+57.82992418942378
+ 13
+284849.7843850265
+ 23
+1237983.845388117
+ 14
+-4.131606192575514
+ 24
+61.00739195811414
+ 13
+624086.2995329766
+ 23
+773980.6529463918
+ 14
+1.668695790633921
+ 24
+56.80332057653687
+ 13
+439652.4432977153
+ 23
+386534.6871775072
+ 14
+-1.405457913071701
+ 24
+53.3742076723859
+ 13
+656230.7300765835
+ 23
+662720.8601069314
+ 14
+2.085792644702956
+ 24
+55.78979338000666
+ 13
+764750.9211121253
+ 23
+628657.732034174
+ 14
+3.763490734839812
+ 24
+55.41577578294906
+ 13
+788042.477642263
+ 23
+501358.907922952
+ 14
+3.958789240388789
+ 24
+54.2603307938781
+ 13
+193062.858238505
+ 23
+1192891.84802285
+ 14
+-5.777854823246726
+ 24
+60.56597508458092
+ 13
+659940.7441265016
+ 23
+460411.3044330981
+ 14
+1.962485898695106
+ 24
+53.9743490506478
+ 13
+499039.672066259
+ 23
+175516.4739450673
+ 14
+-0.5754974791148591
+ 24
+51.46995864188363
+ 13
+228139.2569550059
+ 23
+409385.8154391518
+ 14
+-4.595785701975002
+ 24
+53.55290444628122
+ 13
+701185.7182735109
+ 23
+-81293.29175184256
+ 14
+2.124738351759469
+ 24
+49.09532401706665
+ 13
+511031.9164126738
+ 23
+-21334.93521426685
+ 14
+-0.4616896219391623
+ 24
+49.69813460184241
+ 13
+619168.5032019918
+ 23
+44512.09645951592
+ 14
+1.073619324826661
+ 24
+50.2599142758406
+ 13
+361228.0273272697
+ 23
+1172870.413700639
+ 14
+-2.70627567493019
+ 24
+60.43776979769109
+ 13
+569921.4935376228
+ 23
+914756.0225043283
+ 14
+0.8806376981557162
+ 24
+58.08922753124415
+ 13
+84833.04202102253
+ 23
+-41722.34728471273
+ 14
+-6.349481787255641
+ 24
+49.44311887691573
+ 13
+487705.1572579404
+ 23
+1269013.966625354
+ 14
+-0.3651471322245514
+ 24
+61.29296602777412
+ 13
+407828.4969004292
+ 23
+848405.7318018249
+ 14
+-1.870945680518299
+ 24
+57.52573076331657
+ 13
+492633.8749305174
+ 23
+1085070.570116589
+ 14
+-0.3587113404067495
+ 24
+59.64103145379702
+ 13
+251191.1702166421
+ 23
+783921.1990608401
+ 14
+-4.446385894544569
+ 24
+56.92259869355281
+ 13
+590070.8313224312
+ 23
+520868.3136582582
+ 14
+0.9371295295902045
+ 24
+54.54737391871489
+ 13
+322311.8684454494
+ 23
+7705.151373673048
+ 14
+-3.084550899690172
+ 24
+49.96445455435173
+ 13
+588406.7915613626
+ 23
+193619.847485343
+ 14
+0.7196302624111223
+ 24
+51.60988636117072
+ 13
+524570.2515479706
+ 23
+358026.612940246
+ 14
+-0.1407004442426255
+ 24
+53.10492338340921
+ 13
+436023.9812380602
+ 23
+71235.24130563904
+ 14
+-1.492991673992547
+ 24
+50.53977196197269
+ 13
+482419.1334939237
+ 23
+936069.3516897935
+ 14
+-0.5953281709054139
+ 24
+58.30548775379921
+ 13
+624166.5552711928
+ 23
+983599.2181295633
+ 14
+1.865719493689699
+ 24
+58.68206505701595
+ 13
+291022.8784915965
+ 23
+305274.5221749278
+ 14
+-3.611723856092763
+ 24
+52.63425800723748
+ 13
+359875.3525742679
+ 23
+695118.9032619004
+ 14
+-2.647387494984051
+ 24
+56.14706147983489
+ 13
+537724.8269147282
+ 23
+771074.1761713645
+ 14
+0.2542380265379398
+ 24
+56.81078252847372
+ 13
+347003.8297908098
+ 23
+1013283.257418093
+ 14
+-2.924260383653312
+ 24
+59.00333833720615
+ 13
+591127.1773348192
+ 23
+606730.3663902084
+ 14
+1.010466651787721
+ 24
+55.31750431872055
+ 13
+448641.4271939963
+ 23
+1013235.717678048
+ 14
+-1.155022931767603
+ 24
+59.00346400774501
+ 13
+188945.4250310408
+ 23
+1032999.758578514
+ 14
+-5.690480794356195
+ 24
+59.13122995814595
+ 13
+206144.3795809241
+ 23
+931594.2741293767
+ 14
+-5.303255887396669
+ 24
+58.23026646704402
+ 13
+701119.0253611309
+ 23
+950978.6204184319
+ 14
+3.144893633383687
+ 24
+58.34369083589563
+ 13
+783416.4395613893
+ 23
+852377.1935697602
+ 14
+4.383843396621386
+ 24
+57.39964628300077
+ 13
+481639.5597147312
+ 23
+648883.6534419043
+ 14
+-0.7017555436054596
+ 24
+55.7264934605599
+ 13
+196269.418663505
+ 23
+93936.99793577969
+ 14
+-4.886968503499029
+ 24
+50.70927398384789
+ 13
+110658.7262775896
+ 23
+118104.1290297908
+ 14
+-6.115744219634335
+ 24
+50.88976766522949
+ 13
+709923.0469539247
+ 23
+816215.6252809682
+ 14
+3.120943201377536
+ 24
+57.13210207068633
+ 13
+638409.5901258907
+ 23
+1186300.086303064
+ 14
+2.338713062959207
+ 24
+60.48967913248765
+ 13
+680280.0777606297
+ 23
+1114275.30777163
+ 14
+2.998795191530436
+ 24
+59.81858591511024
+ 13
+798035.4094523196
+ 23
+1095443.170211695
+ 14
+5.048341653890163
+ 24
+59.55460859950111
+ 13
+786412.295946138
+ 23
+998499.4860117874
+ 14
+4.673089469282726
+ 24
+58.70096929947909
+ 13
+238665.7064169336
+ 23
+596057.6522300702
+ 14
+-4.538505690698451
+ 24
+55.23228356397538
+ 13
+319954.0846451608
+ 23
+598028.3770905785
+ 14
+-3.261344598780349
+ 24
+55.26988260470511
+ 13
+52106.94454562735
+ 23
+62071.33860787133
+ 14
+-6.892831518784207
+ 24
+50.35546163668512
+ 13
+165469.7273555683
+ 23
+-35261.64359823676
+ 14
+-5.243017396854679
+ 24
+49.5376163887917
+ 13
+358269.2932293453
+ 23
+85802.34100019458
+ 14
+-2.591884472018448
+ 24
+50.6703717185114
+ 13
+329118.7450621245
+ 23
+464041.8221166885
+ 14
+-3.084566189320475
+ 24
+54.06742668375368
+ 13
+126286.0209718296
+ 23
+319639.0069218271
+ 14
+-6.053241823404439
+ 24
+52.70503152892002
+ 13
+747180.2275391124
+ 23
+1258469.976799443
+ 14
+4.435266497760148
+ 24
+61.0547984135078
+ 13
+578724.4732685266
+ 23
+837335.1371160429
+ 14
+0.9721624963320342
+ 24
+57.39131061299058
+ 13
+158416.4932061777
+ 23
+249403.0441291134
+ 14
+-5.528002394442788
+ 24
+52.09011750506002
+ 13
+245768.1519949077
+ 23
+157098.9549960468
+ 14
+-4.213367422905472
+ 24
+51.29207812741138
+ 13
+366161.1400319935
+ 23
+220476.8787872601
+ 14
+-2.493015039772997
+ 24
+51.88182777576987
+ 13
+152992.6221977407
+ 23
+409675.2708919679
+ 14
+-5.728144049416498
+ 24
+53.52553004609571
+ 13
+439723.8929581424
+ 23
+554626.3485771725
+ 14
+-1.382337524873462
+ 24
+54.8848239992382
+ 13
+548353.4240727401
+ 23
+1170052.888256095
+ 14
+0.6898368317972295
+ 24
+60.38719762290597
+ 13
+321289.1361524442
+ 23
+150385.9233527815
+ 14
+-3.129100654371903
+ 24
+51.2471900376372
+ 13
+234075.3322753516
+ 23
+29861.95676609076
+ 14
+-4.323658515771803
+ 24
+50.1455375510042
+ 13
+586655.1954022487
+ 23
+119247.4898135146
+ 14
+0.6555475762376203
+ 24
+50.94244702999863
+ 13
+771075.3098869145
+ 23
+925722.0735673005
+ 14
+4.292841059773598
+ 24
+58.06476042522177
+ 13
+469172.2531907155
+ 23
+242746.5090210207
+ 14
+-0.9920406526153179
+ 24
+52.07877829821606
+ 13
+604199.9386327924
+ 23
+298288.4708546149
+ 14
+1.009991919280676
+ 24
+52.54416100923879
+ 13
+87214.16829125603
+ 23
+186436.689253705
+ 14
+-6.507560763795996
+ 24
+51.49012979718808
+ 13
+17805.1703537545
+ 23
+213785.7269325344
+ 14
+-7.53270898636328
+ 24
+51.69229207374244
+ 13
+745258.0333831298
+ 23
+559310.9539240255
+ 14
+3.372835200442294
+ 24
+54.80950784687119
+ 13
+206022.4805788152
+ 23
+665652.2452085534
+ 14
+-5.09984241199741
+ 24
+55.8449546906344
+ 13
+731429.8098495486
+ 23
+457615.2173331496
+ 14
+3.045459999278319
+ 24
+53.90850123807025
+ 13
+455138.2259522475
+ 23
+794916.5056761072
+ 14
+-1.092976856183021
+ 24
+57.04203268338761
+ 13
+676709.0780146022
+ 23
+338433.7618152969
+ 14
+2.110435511452836
+ 24
+52.87214776412939
+ 13
+764578.7004992617
+ 23
+294430.877386126
+ 14
+3.362107413493492
+ 24
+52.42607492618525
+ 13
+741286.022102433
+ 23
+195645.0718277914
+ 14
+2.922651670545258
+ 24
+51.55628421451008
+ 13
+744998.5606357881
+ 23
+104087.1909174963
+ 14
+2.888376172017865
+ 24
+50.73379041746335
+ 13
+97487.75996928179
+ 23
+453405.7852445821
+ 14
+-6.605562528177572
+ 24
+53.88832497291168
+ 13
+91154.40328903778
+ 23
+546945.5249494903
+ 14
+-6.798246182305496
+ 24
+54.72236331115585
+ 13
+17508.6161908715
+ 23
+692038.1061705402
+ 14
+-8.133545091087682
+ 24
+55.96834898394494
+ 13
+26807.4741988506
+ 23
+851306.9034092124
+ 14
+-8.216375007400479
+ 24
+57.39833894669525
+ 13
+82733.69049823983
+ 23
+768135.8150290205
+ 14
+-7.184851291574039
+ 24
+56.69677626628928
+ 13
+106880.9005909343
+ 23
+887154.989757521
+ 14
+-6.932602831579652
+ 24
+57.77782151946737
+ 13
+27691.15537665586
+ 23
+956686.5891768824
+ 14
+-8.36644545220332
+ 24
+58.33988604628039
+ 13
+68863.46691459615
+ 23
+1043221.396778385
+ 14
+-7.79451635219857
+ 24
+59.14614870849981
+ 13
+52228.70249457024
+ 23
+1139898.844545989
+ 14
+-8.242031092240804
+ 24
+59.99600312881673
+ 13
+1376.297486709823
+ 23
+1220856.363157046
+ 14
+-9.306873753630998
+ 24
+60.67105010244497
+ 13
+104184.8082213659
+ 23
+679906.234814253
+ 14
+-6.736813736959669
+ 24
+55.92095204526167
+ 13
+101.0895804442734
+ 23
+772960.2931194347
+ 14
+-8.533413267563668
+ 24
+56.67655034197474
+ 13
+51328.24083421878
+ 23
+617967.4226477864
+ 14
+-7.500425109721946
+ 24
+55.33166839784133
+ 13
+351071.3501914416
+ 23
+534755.6857229207
+ 14
+-2.760842594401816
+ 24
+54.70543613655826
+ 13
+292174.3697943031
+ 23
+1057568.530235236
+ 14
+-3.900211208404783
+ 24
+59.39048755786956
+ 13
+471374.786802439
+ 23
+312638.919449887
+ 14
+-0.94504680192251
+ 24
+52.70674135710777
+ 13
+317677.7339986404
+ 23
+949834.9638340146
+ 14
+-3.411349112693222
+ 24
+58.42904471885035
+ 13
+230402.6585169729
+ 23
+478971.3096398383
+ 14
+-4.600135505611648
+ 24
+54.17842809424197
+ 13
+473712.4749454266
+ 23
+493864.8036285739
+ 14
+-0.8678743297653202
+ 24
+54.33504335879713
+ 13
+187975.8440623302
+ 23
+548471.6779396789
+ 14
+-5.299010343730378
+ 24
+54.78622501738828
+ 13
+628818.8664853769
+ 23
+1052695.636826226
+ 14
+2.017284768414711
+ 24
+59.29863843272291
+ 13
+227542.86534488
+ 23
+246458.3779826356
+ 14
+-4.518685742376781
+ 24
+52.08954343512921
+ 13
+160532.8450179035
+ 23
+1253808.891348888
+ 14
+-6.444695490120574
+ 24
+61.09321363366555
+ 13
+147000.2610753299
+ 23
+793273.8605003297
+ 14
+-6.163396481975078
+ 24
+56.96124056313468
+ 13
+595142.5404142353
+ 23
+436731.1229910888
+ 14
+0.9609781369594378
+ 24
+53.79031162796874
+ 13
+383239.8342605015
+ 23
+347454.745473248
+ 14
+-2.251322424481215
+ 24
+53.02413581960888
+ 13
+211679.9454287771
+ 23
+1097713.204874818
+ 14
+-5.350865516540038
+ 24
+59.7220464564415
+ 13
+295576.5920200928
+ 23
+732674.986494296
+ 14
+-3.696791115167204
+ 24
+56.4745714512156
+ 13
+382264.5526713884
+ 23
+422263.4161953457
+ 14
+-2.270084066971151
+ 24
+53.69652128007292
+ 13
+130327.5667063748
+ 23
+1169285.844885879
+ 14
+-6.886357129200062
+ 24
+60.31761533092259
+ 13
+674620.1117493914
+ 23
+201129.9238638063
+ 14
+1.967914893938517
+ 24
+51.64185877480679
+ 13
+339109.9050545648
+ 23
+1109911.534743496
+ 14
+-3.089198604506068
+ 24
+59.86983923707923
+ 13
+60020.37972017477
+ 23
+321933.9486753989
+ 14
+-7.032827746212584
+ 24
+52.68805739104035
+ 13
+45981.1055167322
+ 23
+1269753.890991128
+ 14
+-8.585827733336309
+ 24
+61.14914456930446
+ 13
+751142.1006724852
+ 23
+-37920.66879270441
+ 14
+2.844761219698775
+ 24
+49.45763601524093
+ 13
+665055.1709800353
+ 23
+-25873.00560117362
+ 14
+1.667752055768888
+ 24
+49.60940681420049
+ 13
+678906.5029213367
+ 23
+72931.9225134936
+ 14
+1.930915366382555
+ 24
+50.48974924470174
+ 13
+769505.7936062075
+ 23
+787885.2913989921
+ 14
+4.05857371258213
+ 24
+56.83509600473922
+ 13
+723520.9322652188
+ 23
+880450.1008871447
+ 14
+3.429174218726163
+ 24
+57.69719094653444
+ 13
+107414.2903451365
+ 23
+1291648.288912482
+ 14
+-7.484182127977265
+ 24
+61.39546201052976
+ 13
+555085.3940442184
+ 23
+1067261.30526535
+ 14
+0.7348387299673087
+ 24
+59.46277336913567
+ 13
+571569.3353602529
+ 23
+964.7280506510796
+ 14
+0.3869938760122447
+ 24
+49.88434224327135
+ 13
+416657.4151965381
+ 23
+1205808.761075005
+ 14
+-1.696427030702431
+ 24
+60.73503536734479
+ 13
+639822.0370005225
+ 23
+1250565.63744474
+ 14
+2.443406536082783
+ 24
+61.06411030601037
+ 13
+701838.2787726434
+ 23
+618123.5354618838
+ 14
+2.762002385432278
+ 24
+55.36419274481104
+ 13
+420113.8335867424
+ 23
+1142114.512261291
+ 14
+-1.639438207355982
+ 24
+60.16301153541896
+ 13
+614787.0629085296
+ 23
+711020.6074004065
+ 14
+1.464739217875432
+ 24
+56.24312734898893
+ 13
+735740.9774689422
+ 23
+1083494.567638898
+ 14
+3.933643949036621
+ 24
+59.50250262513555
+ 13
+358483.2157245717
+ 23
+888207.451789936
+ 14
+-2.701725688255897
+ 24
+57.88136311543898
+ 13
+223598.8098517338
+ 23
+1253025.385235284
+ 14
+-5.276568488347931
+ 24
+61.11957456439928
+ 13
+269209.7336164382
+ 23
+1306527.130203069
+ 14
+-4.468474347236864
+ 24
+61.617282461895
+ 13
+331035.188699014
+ 23
+1284578.323862479
+ 14
+-3.294810364423013
+ 24
+61.43637218010103
+ 13
+18351.46742849059
+ 23
+275885.8588660871
+ 14
+-7.59380564576528
+ 24
+52.24835565590693
+ 13
+457423.9137347544
+ 23
+129483.9280729279
+ 14
+-1.181931315534001
+ 24
+51.06182420138964
+ 13
+254281.7206675945
+ 23
+1184242.260325828
+ 14
+-4.656126634396222
+ 24
+60.51530356989275
+ 13
+250792.9114206517
+ 23
+352022.0886015841
+ 14
+-4.227149908715971
+ 24
+53.04460408507569
+ 13
+84527.9585122827
+ 23
+829730.9261040416
+ 14
+-7.232596055349166
+ 24
+57.24903406209786
+ 13
+667553.2736698999
+ 23
+399316.4556176583
+ 14
+2.025555710571627
+ 24
+53.42271000850159
+ 13
+346523.8225745017
+ 23
+278764.8835380335
+ 14
+-2.787470751651645
+ 24
+52.4042797095011
+ 13
+724633.866683621
+ 23
+675114.5227192569
+ 14
+3.187254335826951
+ 24
+55.85968606325094
+ 13
+298953.2229113146
+ 23
+822406.3590906956
+ 14
+-3.677726768317533
+ 24
+57.28105718577277
+ 13
+235823.3107638924
+ 23
+719174.4740295979
+ 14
+-4.65737411964692
+ 24
+56.336377459373
+ 13
+463615.9810477113
+ 23
+16918.66531962149
+ 14
+-1.112790680123695
+ 24
+50.04899647455093
+ 13
+129451.7427357404
+ 23
+1044540.121131013
+ 14
+-6.740929401452803
+ 24
+59.20084956874637
+ 13
+402234.9213585345
+ 23
+765952.967233425
+ 14
+-1.965050952635883
+ 24
+56.78512041774501
+ 13
+505810.5533717736
+ 23
+719959.462394163
+ 14
+-0.2890596463175736
+ 24
+56.3601309806924
+ 13
+530344.9198494426
+ 23
+514031.4456354627
+ 14
+0.0114702316527079
+ 24
+54.50486140633097
+ 13
+708067.409521402
+ 23
+512579.9777530852
+ 14
+2.747217910202274
+ 24
+54.41521547818624
+ 13
+246011.2804390045
+ 23
+849930.6890116626
+ 14
+-4.572314420565134
+ 24
+57.51327134316202
+ 13
+757369.2109330716
+ 23
+1139096.396998249
+ 14
+4.408004319868624
+ 24
+59.98084822872997
+ 13
+787219.6014870017
+ 23
+1201765.863849234
+ 14
+5.058683753789765
+ 24
+60.51237768752089
+ 13
+668959.8520898603
+ 23
+735186.0280267347
+ 14
+2.361149653539209
+ 24
+56.43209838084621
+ 13
+414804.5205480811
+ 23
+674077.00362504
+ 14
+-1.764474884201246
+ 24
+55.95948223411069
+ 13
+436082.8327428631
+ 23
+899930.2726364531
+ 14
+-1.391472800076439
+ 24
+57.98714897430973
+ 13
+537552.1704624797
+ 23
+630842.8191869221
+ 14
+0.1788669886273464
+ 24
+55.5518873811768
+ 13
+284239.807747122
+ 23
+426347.5950676853
+ 14
+-3.755781047654793
+ 24
+53.72066591979412
+ 13
+423034.7593670667
+ 23
+206781.0113033356
+ 14
+-1.667648184331353
+ 24
+51.75925135409917
+ 13
+470771.2435416452
+ 23
+435728.8246671604
+ 14
+-0.926650601203384
+ 24
+53.81305891397124
+ 13
+514888.9197057286
+ 23
+1217608.852052153
+ 14
+0.1108954073208762
+ 24
+60.82475571143614
+ 13
+341932.5531752861
+ 23
+1227589.432276822
+ 14
+-3.073020387147892
+ 24
+60.9266377651436
+ 13
+725604.1575460972
+ 23
+251481.6843851466
+ 14
+2.749656913746571
+ 24
+52.06586330554377
+ 13
+783904.541903769
+ 23
+237735.0525124849
+ 14
+3.580949842682513
+ 24
+51.90559563280565
+ 13
+51370.43568202721
+ 23
+903794.4740964039
+ 14
+-7.885527136377688
+ 24
+57.88681912323976
+ 13
+375476.8733953623
+ 23
+30553.31088154455
+ 14
+-2.344766255904617
+ 24
+50.17450408810556
+ 13
+618368.8031730373
+ 23
+242624.7687804664
+ 14
+1.182563861494081
+ 24
+52.03901093011211
+ 13
+76759.61123608623
+ 23
+986402.4272534482
+ 14
+-7.574538186859035
+ 24
+58.64441083397922
+ 13
+263449.9928067802
+ 23
+931304.739257335
+ 14
+-4.328230599418634
+ 24
+58.24917406445266
+ 13
+625724.8373046295
+ 23
+926578.5464039501
+ 14
+1.836477023421446
+ 24
+58.17030444645003
+ 13
+190401.3355058555
+ 23
+366797.0522382942
+ 14
+-5.136382324969671
+ 24
+53.15695618883154
+ 13
+653404.4440828414
+ 23
+822738.7263047486
+ 14
+2.196557691451176
+ 24
+57.22515824341027
+ 13
+694832.0832176536
+ 23
+1236440.586617853
+ 14
+3.436476518495475
+ 24
+60.90058092589951
+ 13
+82867.05711881449
+ 23
+14713.88271954851
+ 14
+-6.422367245163839
+ 24
+49.94819630798034
+ 13
+87603.92654395969
+ 23
+1096215.816846827
+ 14
+-7.545561817660883
+ 24
+59.6340209283355
+ 13
+30896.53927456418
+ 23
+1086458.484088425
+ 14
+-8.527913323456376
+ 24
+59.50069402435319
+ 13
+1391.541541761606
+ 23
+1022261.727475825
+ 14
+-8.927768959356985
+ 24
+58.90150581181085
+ 13
+50996.76881009367
+ 23
+1195574.916936011
+ 14
+-8.35994620676686
+ 24
+60.49183413150387
+ 13
+104349.5990043826
+ 23
+601022.2353292952
+ 14
+-6.64979108528623
+ 24
+55.21464471374458
+ 13
+161009.7959680828
+ 23
+899329.3905600035
+ 14
+-6.037112681580854
+ 24
+57.9190349496428
+ 13
+644893.6009941443
+ 23
+513624.0716948755
+ 14
+1.776918477082315
+ 24
+54.45889465262261
+ 13
+532967.0008983224
+ 23
+131997.3200257494
+ 14
+-0.1034602485581399
+ 24
+51.07190604946496
+ 13
+712693.6360436548
+ 23
+148631.4828086895
+ 14
+2.47026440377207
+ 24
+51.15141169921199
+ 13
+645998.2656956242
+ 23
+608773.5915956187
+ 14
+1.875021223815994
+ 24
+55.31148644194201
+ 13
+537653.557839808
+ 23
+214531.0446011425
+ 14
+-0.0045390161239855
+ 24
+51.81247575628692
+ 13
+355281.0111372912
+ 23
+833747.9829389002
+ 14
+-2.745615908476609
+ 24
+57.39192397036341
+ 13
+306794.6435405144
+ 23
+1169525.868673816
+ 14
+-3.693334994201713
+ 24
+60.39883942893001
+ 13
+5037.690335386047
+ 23
+1166706.323722178
+ 14
+-9.133361450397273
+ 24
+60.19231900827566
+ 13
+397813.9709044723
+ 23
+994749.9955785193
+ 14
+-2.039602451858767
+ 24
+58.84019473447948
+ 13
+732513.019100816
+ 23
+994935.9622734084
+ 14
+3.742609664209183
+ 24
+58.71388202103216
+ 13
+535677.2078780494
+ 23
+1117606.46972025
+ 14
+0.4251850289104119
+ 24
+59.92115966982473
+ 13
+121707.4646794758
+ 23
+730888.9686522485
+ 14
+-6.510621337681755
+ 24
+56.38804425814047
+ 13
+65211.03404012994
+ 23
+717153.0811910251
+ 14
+-7.404341217225351
+ 24
+56.22860430109788
+ 13
+350905.5377930986
+ 23
+642054.4820803607
+ 14
+-2.782081810831933
+ 24
+55.66949725773955
+ 13
+182189.5083149915
+ 23
+15823.3005687298
+ 14
+-5.04091568010825
+ 24
+50.00266991646617
+ 13
+553693.0975688589
+ 23
+402905.3374861167
+ 14
+0.3156743475624438
+ 24
+53.5004142960923
+ 13
+601877.3695775518
+ 23
+659120.4453312517
+ 14
+1.217799452573132
+ 24
+55.78322027724097
+ 13
+239018.9704304724
+ 23
+1051758.552999711
+ 14
+-4.830648738135947
+ 24
+59.3213982193842
+ 13
+199985.0086872095
+ 23
+798504.4692178338
+ 14
+-5.297824238387737
+ 24
+57.0341092139389
+ 13
+180954.8762340406
+ 23
+1141113.421506664
+ 14
+-5.941777914664728
+ 24
+60.09577191823095
+ 13
+184440.3031364016
+ 23
+980074.4008145946
+ 14
+-5.71767589980646
+ 24
+58.65468584521746
+ 13
+460089.6702037676
+ 23
+-35965.44856741887
+ 14
+-1.170214125425144
+ 24
+49.57378277700107
+ 13
+450388.2344523951
+ 23
+606332.4560533924
+ 14
+-1.206980001634871
+ 24
+55.3484458945568
+ 13
+519689.0664545502
+ 23
+898803.7791714956
+ 14
+0.0212029166014326
+ 24
+57.96243611686169
+ 13
+532651.5605769962
+ 23
+952021.595022626
+ 14
+0.2703770341053018
+ 24
+58.43637820122999
+ 13
+729152.9768834831
+ 23
+333424.1674564457
+ 14
+2.881863488408876
+ 24
+52.79780342125596
+ 13
+797277.1551503639
+ 23
+359726.6165926988
+ 14
+3.919277779118793
+ 24
+52.98723251966507
+ 13
+797319.8376102972
+ 23
+430846.6039360744
+ 14
+4.008827928150123
+ 24
+53.62301386788687
+ 13
+32454.23712651808
+ 23
+-41117.24508505322
+ 14
+-7.069915056982943
+ 24
+49.41915659567734
+ 13
+153825.257880561
+ 23
+663645.8036105536
+ 14
+-5.929757150345237
+ 24
+55.80316855253901
+ 13
+621059.3872270768
+ 23
+562896.4780918174
+ 14
+1.447226334784498
+ 24
+54.91181635502125
+ 13
+774635.0953758664
+ 23
+1049080.141331389
+ 14
+4.556561916695739
+ 24
+59.16261766992748
+ 13
+92955.64709822585
+ 23
+937123.2962073802
+ 14
+-7.230737432831103
+ 24
+58.2154637342768
+ 13
+134946.4263252964
+ 23
+843635.6600866195
+ 14
+-6.414612486186607
+ 24
+57.40556150963639
+ 13
+588106.6325608305
+ 23
+1020731.989543388
+ 14
+1.276195879995279
+ 24
+59.03215292999227
+ 13
+496254.3894645706
+ 23
+1033465.173683861
+ 14
+-0.3176513522918476
+ 24
+59.17700597863614
+ 13
+556367.7520287182
+ 23
+317470.5922039366
+ 14
+0.3143853286011636
+ 24
+52.73228899066248
+ 13
+333546.1081834399
+ 23
+334202.9203039879
+ 14
+-2.989391057749586
+ 24
+52.90115342385649
+ 13
+139828.0539239701
+ 23
+531027.9110907321
+ 14
+-6.030399482653868
+ 24
+54.60720986325852
+ 13
+390347.0750068667
+ 23
+567223.9240234786
+ 14
+-2.152436852811846
+ 24
+54.99950013974102
+ 13
+563198.5371410181
+ 23
+564136.4432418975
+ 14
+0.546403497149414
+ 24
+54.94519117237057
+ 13
+43143.51641481886
+ 23
+800112.7674474444
+ 14
+-7.872747089097605
+ 24
+56.95401419055711
+ 13
+554877.256000007
+ 23
+-47041.89981751285
+ 14
+0.135802701101507
+ 24
+49.45741011855744
+ 13
+439472.0909661265
+ 23
+963246.1939000837
+ 14
+-1.323407467705409
+ 24
+58.55549340770357
+ 13
+527736.6775581509
+ 23
+26637.26511405374
+ 14
+-0.2142788740641675
+ 24
+50.12607343802661
+ 13
+630703.1071005583
+ 23
+93970.25895720904
+ 14
+1.265663543455127
+ 24
+50.69959031636859
+ 13
+607134.4776060863
+ 23
+879371.0660908375
+ 14
+1.479789609630369
+ 24
+57.75618367192471
+ 13
+575286.9290360111
+ 23
+69861.69173573752
+ 14
+0.4704446220140489
+ 24
+50.5023189761421
+ 13
+190696.5048502694
+ 23
+443427.0921992221
+ 14
+-5.18311976404356
+ 24
+53.84480714806867
+ 13
+446821.4862168949
+ 23
+1063738.423210592
+ 14
+-1.175835956172723
+ 24
+59.45714065896222
+ 13
+651320.4297343688
+ 23
+-74314.76198647247
+ 14
+1.447393121019635
+ 24
+49.18034576798881
+ 13
+215768.1594055862
+ 23
+197518.590551313
+ 14
+-4.664249219353734
+ 24
+51.64621068340018
+ 13
+665224.7692187735
+ 23
+24387.72615026333
+ 14
+1.704464843884077
+ 24
+50.06044301969026
+ 13
+441403.4809490012
+ 23
+1249526.485108448
+ 14
+-1.233351700751559
+ 24
+61.12568787564796
+ 13
+280530.9542694319
+ 23
+476599.5947145095
+ 14
+-3.831633158501198
+ 24
+54.17124918309863
+ 13
+133469.5343671859
+ 23
+205872.0981767315
+ 14
+-5.857694738656627
+ 24
+51.68818262841949
+ 13
+273095.9511422915
+ 23
+-1517.157230767763
+ 14
+-3.767431828947628
+ 24
+49.87311403816999
+ 13
+308426.7969304167
+ 23
+-54129.93125265884
+ 14
+-3.263586145005638
+ 24
+49.40646616311983
+ 13
+359488.2414042905
+ 23
+-33119.29353973092
+ 14
+-2.561962645269307
+ 24
+49.60098963340428
+ 13
+317530.6800878395
+ 23
+57232.8354243939
+ 14
+-3.161951892186637
+ 24
+50.4091430490549
+ 13
+762331.8215072538
+ 23
+150644.2388317346
+ 14
+3.179241525665876
+ 24
+51.14021276045992
+ 13
+353810.3830977845
+ 23
+1062475.890924528
+ 14
+-2.816280335323581
+ 24
+59.44584195503864
+ 13
+581728.667992532
+ 23
+748070.1264246509
+ 14
+0.9577926409203506
+ 24
+56.58931605074779
+ 13
+493934.5785154698
+ 23
+984114.1343051376
+ 14
+-0.3791427217605335
+ 24
+58.73450688287629
+ 13
+467225.6350247088
+ 23
+1127388.424857241
+ 14
+-0.7956129016772176
+ 24
+60.02579456595313
+ 13
+620522.3861926018
+ 23
+-4755.421174295621
+ 14
+1.064236509522477
+ 24
+49.816953657972
+ 13
+672685.7950595288
+ 23
+990980.5152702084
+ 14
+2.708736258104345
+ 24
+58.72032701305812
+ 13
+159076.2187319641
+ 23
+125901.2735820482
+ 14
+-5.433864735582841
+ 24
+50.98198436722962
+ 13
+567662.1254403581
+ 23
+477296.0841658616
+ 14
+0.5665844429688443
+ 24
+54.16410107809355
+ 13
+232195.6990954672
+ 23
+527765.8840022922
+ 14
+-4.600264348909836
+ 24
+54.61708921132455
+ 13
+576537.4586448218
+ 23
+973234.4816412846
+ 14
+1.037420703871093
+ 24
+58.61113307395614
+ 13
+488157.7167116754
+ 23
+390291.1415289814
+ 14
+-0.6754981208193696
+ 24
+53.40211304315468
+ 13
+127925.9644797764
+ 23
+368131.5606945886
+ 14
+-6.069665364861076
+ 24
+53.14068103834608
+ 13
+430842.4203647347
+ 23
+338995.8298852172
+ 14
+-1.542434240452339
+ 24
+52.9474840429316
+ 13
+125296.829440686
+ 23
+-8408.72897279555
+ 14
+-5.815914769419629
+ 24
+49.76172899396655
+ 13
+58020.32761640685
+ 23
+665779.0571420034
+ 14
+-7.454486272832379
+ 24
+55.76403959546034
+ 13
+229195.1981990897
+ 23
+1142995.012671698
+ 14
+-5.077323944296058
+ 24
+60.13563231749087
+ 13
+590693.4265982997
+ 23
+1193076.177876313
+ 14
+1.478617016374794
+ 24
+60.5758211179143
+ 13
+633324.6197963902
+ 23
+176583.2437542191
+ 14
+1.355979749167967
+ 24
+51.44016454652333
+ 13
+402131.2856252214
+ 23
+105125.3077995028
+ 14
+-1.971088255818099
+ 24
+50.84563769602002
+ 13
+98881.20191998893
+ 23
+71802.71662176189
+ 14
+-6.245039217020687
+ 24
+50.4685221316494
+ 13
+102990.9202145782
+ 23
+500762.6695605661
+ 14
+-6.568583764293055
+ 24
+54.31578397228187
+ 13
+424060.3414666154
+ 23
+445149.3775923094
+ 14
+-1.635304727468871
+ 24
+53.90197092451574
+ 13
+788605.2979607042
+ 23
+190353.4290310951
+ 14
+3.596254053431268
+ 24
+51.4783769217217
+ 13
+534395.7256133169
+ 23
+1260814.470187585
+ 14
+0.4995362873207542
+ 24
+61.20614902584602
+ 13
+677318.614911184
+ 23
+781829.3285012099
+ 14
+2.546331676806194
+ 24
+56.84499401942818
+ 13
+678818.5149597699
+ 23
+1161608.419389152
+ 14
+3.037024261707654
+ 24
+60.24295261678043
+ 13
+501940.6328758813
+ 23
+802078.1396631493
+ 14
+-0.3190680441920067
+ 24
+57.09838539493611
+ 13
+272295.8976751495
+ 23
+261821.5469748557
+ 14
+-3.871670588023904
+ 24
+52.2397364247462
+ 13
+454471.1484106918
+ 23
+856337.5979395027
+ 14
+-1.090435109646361
+ 24
+57.59377879161738
+ 13
+64882.89955857968
+ 23
+107329.4352472859
+ 14
+-6.754590472585152
+ 24
+50.76848766238202
+ 13
+279876.588631085
+ 23
+573668.080909642
+ 14
+-3.881449555464963
+ 24
+55.04295984329207
+ 13
+153499.827148179
+ 23
+1300139.351078747
+ 14
+-6.63558988169956
+ 24
+61.50344421190527
+ 13
+481566.617770251
+ 23
+60203.76498803516
+ 14
+-0.8528036933441139
+ 24
+50.43601856335421
+ 13
+278859.5873283762
+ 23
+620489.0930834923
+ 14
+-3.917500122320559
+ 24
+55.46319866546284
+ 13
+216199.7501875459
+ 23
+885940.1555805339
+ 14
+-5.09666249190039
+ 24
+57.82513011512039
+ 13
+399431.5588459378
+ 23
+719546.6278019138
+ 14
+-2.010811282068049
+ 24
+56.36822176170642
+ 13
+613980.9393927233
+ 23
+479083.7251566349
+ 14
+1.276180345035066
+ 24
+54.16294602823466
+ 13
+20071.47806905026
+ 23
+95546.98075765738
+ 14
+-7.375261811044575
+ 24
+50.63541381914298
+ 13
+4806.253050027756
+ 23
+48872.04433017197
+ 14
+-7.541001959120745
+ 24
+50.20749326003844
+ 13
+724044.6543544909
+ 23
+62857.61070061772
+ 14
+2.55659077038487
+ 24
+50.37625493608592
+ 13
+789112.0059917151
+ 23
+26320.89308880718
+ 14
+3.430447723636894
+ 24
+50.00978239443725
+ 13
+639846.4809536408
+ 23
+1136715.910836009
+ 14
+2.305962129516453
+ 24
+60.04490348111147
+ 13
+238940.6057352661
+ 23
+111473.012529055
+ 14
+-4.290853499144173
+ 24
+50.88023889991863
+ 13
+202801.3575654989
+ 23
+139682.1370299011
+ 14
+-4.819307349476043
+ 24
+51.12239699102285
+ 13
+359865.1200499793
+ 23
+175098.6366136781
+ 14
+-2.579247902873161
+ 24
+51.47341649623554
+ 13
+127744.0483392961
+ 23
+160511.9085468194
+ 14
+-5.905364028758237
+ 24
+51.27853342278396
+ 13
+152590.1444056069
+ 23
+80733.27432758398
+ 14
+-5.495697812600078
+ 24
+50.57381339929818
+ 13
+120358.8608262613
+ 23
+274460.281009555
+ 14
+-6.102794003147719
+ 24
+52.29690056078217
+ 13
+707686.9051130526
+ 23
+293305.7454672957
+ 14
+2.52719897217017
+ 24
+52.45094155105237
+ 13
+484414.6719448967
+ 23
+760101.6866736282
+ 14
+-0.6221945731169308
+ 24
+56.72495119624726
+ 13
+358626.8745817379
+ 23
+969409.5565782424
+ 14
+-2.713813264051309
+ 24
+58.61063776538554
+ 13
+481978.59591206
+ 23
+538375.6576152952
+ 14
+-0.7284160218062109
+ 24
+54.7336958616459
+ 13
+150980.651804638
+ 23
+1209563.852715822
+ 14
+-6.564210204021081
+ 24
+60.69131165540294
+ 13
+573364.9244837657
+ 23
+241926.9270042361
+ 14
+0.5268062877641395
+ 24
+52.048629564372
+ 13
+454109.7083548829
+ 23
+174307.7900068152
+ 14
+-1.22244688393555
+ 24
+51.46516275460558
+ 13
+569442.0249413445
+ 23
+360464.581627981
+ 14
+0.5302315545409174
+ 24
+53.11447214709704
+ 13
+315035.82252975
+ 23
+692170.4805861887
+ 14
+-3.367949010553732
+ 24
+56.11469191825086
+ 13
+340416.1220646107
+ 23
+735623.4091700077
+ 14
+-2.969718953490348
+ 24
+56.5088696908857
+ 13
+409987.7816058943
+ 23
+1038003.070625759
+ 14
+-1.826749426562147
+ 24
+59.22851648772855
+ 13
+298859.6809275528
+ 23
+777480.6607679391
+ 14
+-3.66114201027249
+ 24
+56.87763848951204
+ 13
+17162.0438782289
+ 23
+647123.7436781811
+ 14
+-8.076088414905687
+ 24
+55.56681695063809
+ 13
+420284.0071324444
+ 23
+29263.88109339586
+ 14
+-1.717357781937054
+ 24
+50.16306871132564
+ 13
+163016.6596770017
+ 23
+293974.7173047788
+ 14
+-5.492328399368461
+ 24
+52.49207895319194
+ 13
+576989.5387016017
+ 23
+792593.6901574238
+ 14
+0.9115403791044835
+ 24
+56.99059122451703
+ 13
+768667.5182777178
+ 23
+66118.59292006066
+ 14
+3.184875424655566
+ 24
+50.37923149041609
+ 13
+798094.5524594655
+ 23
+110824.5949842721
+ 14
+3.644557190714623
+ 24
+50.7601861825702
+ 13
+669697.1354567543
+ 23
+1070826.796291457
+ 14
+2.755350045002528
+ 24
+59.43682235494421
+ 13
+361413.8919832735
+ 23
+130408.5508588368
+ 14
+-2.552112575395803
+ 24
+51.0716937254106
+ 13
+246897.437231179
+ 23
+298529.4342087247
+ 14
+-4.2601446263125
+ 24
+52.56300996512241
+ 13
+96825.74407999426
+ 23
+1139849.023028447
+ 14
+-7.446249730108609
+ 24
+60.03088199958923
+ 13
+207630.5011137528
+ 23
+-20781.98804253468
+ 14
+-4.668101928014523
+ 24
+49.68257261868251
+ 13
+202176.2279440193
+ 23
+-73520.76034192866
+ 14
+-4.717289542314634
+ 24
+49.20697855256039
+ 13
+302441.8126069417
+ 23
+1014195.890329241
+ 14
+-3.700066455804443
+ 24
+59.00367327640607
+ 13
+40460.71473472612
+ 23
+754162.3296139362
+ 14
+-7.852193152851567
+ 24
+56.5413232793053
+ 13
+202268.8424041855
+ 23
+621438.686231638
+ 14
+-5.12788308261845
+ 24
+55.44676724019161
+ 13
+211568.1323486334
+ 23
+755977.0932438699
+ 14
+-5.075775443348053
+ 24
+56.65750333618269
+ 13
+377285.576299811
+ 23
+1131864.621339926
+ 14
+-2.409913347930892
+ 24
+60.0708303613661
+ 13
+39186.7229798441
+ 23
+20010.7166987042
+ 14
+-7.03392253050748
+ 24
+49.97088295156744
+ 13
+275253.959908583
+ 23
+45221.46904888889
+ 14
+-3.752696937376565
+ 24
+50.29370627447358
+ 13
+704787.8637281522
+ 23
+422662.7852290261
+ 14
+2.606811036615437
+ 24
+53.61171012881116
+ 13
+319518.1758297398
+ 23
+106492.7874951692
+ 14
+-3.144696222251451
+ 24
+50.85232216435842
+ 13
+647512.3918630427
+ 23
+305613.3930267304
+ 14
+1.652911818578972
+ 24
+52.59193603979785
+ 13
+708930.5481056418
+ 23
+-25952.38367372405
+ 14
+2.273380579172878
+ 24
+49.58789875862811
+ 13
+549991.9205007357
+ 23
+172430.5067764214
+ 14
+0.1563010058432153
+ 24
+51.4310306793418
+ 13
+294577.9508821234
+ 23
+354297.4371759442
+ 14
+-3.575084323694166
+ 24
+53.07548226618853
+ 13
+390739.7713389823
+ 23
+808148.9111095216
+ 14
+-2.154749333181482
+ 24
+57.16408458233267
+ 13
+771902.2670249315
+ 23
+395301.8517398481
+ 14
+3.584393732065565
+ 24
+53.32369717936141
+ 13
+685726.4430876695
+ 23
+694890.2608213582
+ 14
+2.588699578402329
+ 24
+56.06140134789752
+ 13
+690260.7133013825
+ 23
+908707.6970271821
+ 14
+2.907636734271193
+ 24
+57.97275020165365
+ 13
+285421.578272231
+ 23
+175037.7735653594
+ 14
+-3.650746462068596
+ 24
+51.46267939279699
+ 13
+542908.89404265
+ 23
+862020.8836413983
+ 14
+0.3913419030002134
+ 24
+57.62550184566194
+ 13
+514379.2355737673
+ 23
+306119.2272394525
+ 14
+-0.3110584507885192
+ 24
+52.64078844247542
+ 13
+495904.8944677602
+ 23
+109417.6177065926
+ 14
+-0.6382250898463801
+ 24
+50.87629987652755
+ 13
+226594.0221030324
+ 23
+969847.7924311491
+ 14
+-4.984445934183937
+ 24
+58.58189746417121
+ 13
+175255.5956417867
+ 23
+1074159.303195032
+ 14
+-5.97194009169172
+ 24
+59.49295069085497
+ 13
+361327.4829248186
+ 23
+492807.298662501
+ 14
+-2.596170177389507
+ 24
+54.32936915604337
+ 13
+318862.6123287475
+ 23
+505990.2091771082
+ 14
+-3.252625169689718
+ 24
+54.44282218699859
+ 13
+280955.8759087825
+ 23
+132113.134399395
+ 14
+-3.700692733137386
+ 24
+51.07595400244527
+ 13
+513834.9866407549
+ 23
+677582.7051494807
+ 14
+-0.1773747447544905
+ 24
+55.97773830590362
+ 13
+137955.3142672086
+ 23
+574067.4177626013
+ 14
+-6.098219293828993
+ 24
+54.99203103584838
+ 13
+509368.7588409629
+ 23
+1151720.300079212
+ 14
+-0.0268505678815228
+ 24
+60.23509457739114
+ 13
+327824.6971785242
+ 23
+240013.196315037
+ 14
+-3.054008035926987
+ 24
+52.05379112278771
+ 13
+163916.5327424314
+ 23
+942257.942378033
+ 14
+-6.031436566048051
+ 24
+58.30520627511903
+ 13
+471920.5066758545
+ 23
+1219233.966932083
+ 14
+-0.6783542387470934
+ 24
+60.84942465956468
+ 13
+240805.5996721846
+ 23
+640433.1140655632
+ 14
+-4.530256175693906
+ 24
+55.63132297323366
+ 13
+473010.9894406498
+ 23
+690971.8401170029
+ 14
+-0.8277468938110027
+ 24
+56.10594068330584
+ 13
+3289.011802194208
+ 23
+815598.6826081312
+ 14
+-8.548198416578808
+ 24
+57.05981688481973
+ 13
+152656.3584364291
+ 23
+1008648.223669267
+ 14
+-6.295476919924012
+ 24
+58.89361306709465
+ 13
+44942.59664272217
+ 23
+180906.7688659743
+ 14
+-7.108552812713011
+ 24
+51.41566525457824
+ 13
+1665.966677067456
+ 23
+172826.1155610809
+ 14
+-7.718849262847111
+ 24
+51.31465208738759
+ 13
+12443.30429955424
+ 23
+1124802.426000846
+ 14
+-8.921963163639647
+ 24
+59.82588429586049
+ 13
+714849.4844705374
+ 23
+1139031.870977799
+ 14
+3.649877319502518
+ 24
+60.01499751691316
+ 13
+477784.6174324372
+ 23
+891846.3424387068
+ 14
+-0.6890415959498183
+ 24
+57.9092381527098
+ 13
+541869.2791834171
+ 23
+816359.9060818253
+ 14
+0.3475501697793282
+ 24
+57.21601425708798
+ 13
+42026.2263426539
+ 23
+1010533.670535088
+ 14
+-8.207944708166685
+ 24
+58.83260832427557
+ 13
+126125.1758751104
+ 23
+-50645.98010372261
+ 14
+-5.775045215995906
+ 24
+49.3830375116053
+ 13
+159423.1777541685
+ 23
+-77800.81895698109
+ 14
+-5.300765163230287
+ 24
+49.15325383687345
+ 13
+702960.0635616403
+ 23
+107585.9684697211
+ 14
+2.297341405114406
+ 24
+50.78859632454733
+ 13
+728498.9376585015
+ 23
+778462.6932819445
+ 14
+3.377484923877144
+ 24
+56.78158283531391
+ 13
+750929.9029016306
+ 23
+825638.2233980158
+ 14
+3.808241538268681
+ 24
+57.18688867079869
+ 13
+225260.3361744262
+ 23
+1011850.957218561
+ 14
+-5.040114875485659
+ 24
+58.95805725176372
+ 13
+492368.5311135059
+ 23
+608252.1425574562
+ 14
+-0.5445369018093431
+ 24
+55.35960513667601
+ 13
+118758.3315433353
+ 23
+640494.5074252812
+ 14
+-6.46377332270594
+ 24
+55.57666452275539
+ 13
+59287.62484615488
+ 23
+220385.5150422367
+ 14
+-6.941360197975123
+ 24
+51.77811410604461
+ 13
+691091.9686011652
+ 23
+853758.5178108907
+ 14
+2.85516913950024
+ 24
+57.48044085200317
+ 13
+747930.6832894645
+ 23
+1216511.712335031
+ 14
+4.37372805504292
+ 24
+60.67979989964704
+ 13
+91739.43577207742
+ 23
+1185681.181506848
+ 14
+-7.606838352354954
+ 24
+60.43666434235394
+ 13
+361812.6881010428
+ 23
+597850.1093324445
+ 14
+-2.60260000949755
+ 24
+55.27330945594
+ 13
+635631.7596325321
+ 23
+1095100.073321697
+ 14
+2.183373789489021
+ 24
+59.6746745008683
+ 13
+635657.2163600226
+ 23
+426363.8406650914
+ 14
+1.566943455872807
+ 24
+53.68056471769855
+ 13
+749563.3396806026
+ 23
+517720.1183599223
+ 14
+3.389966105293248
+ 24
+54.43443300321676
+ 13
+659340.8216528229
+ 23
+951388.8710076477
+ 14
+2.433951551470584
+ 24
+58.37403326033197
+ 13
+197489.0239767099
+ 23
+504611.0091254369
+ 14
+-5.121051189511251
+ 24
+54.39658227940761
+ 13
+111512.0224335045
+ 23
+414116.0792400822
+ 14
+-6.356221566314057
+ 24
+53.54420582185158
+ 13
+138968.359733518
+ 23
+448964.9768964677
+ 14
+-5.972275072196722
+ 24
+53.87104985637982
+ 13
+340633.9837192262
+ 23
+423997.9444544017
+ 14
+-2.90086604844383
+ 24
+53.70902714742253
+ 13
+754242.8989136697
+ 23
+3588.424350924628
+ 14
+2.924856555748628
+ 24
+49.82781617423613
+ 13
+794662.1398756774
+ 23
+-20301.3240837917
+ 14
+3.460268278186914
+ 24
+49.58873398827276
+ 13
+401508.7729276899
+ 23
+242326.9103280138
+ 14
+-1.97938913110958
+ 24
+52.07931046809282
+ 13
+5480.26632045546
+ 23
+731784.0332452091
+ 14
+-8.383862940195792
+ 24
+56.31351633110977
+ 13
+612909.4325316877
+ 23
+813894.7948934644
+ 14
+1.51968927123682
+ 24
+57.16645790159594
+ 13
+262157.9392992453
+ 23
+1086124.441078429
+ 14
+-4.446707285562895
+ 24
+59.63791158042813
+ 13
+729946.0917186713
+ 23
+921312.9262119975
+ 14
+3.593034121475848
+ 24
+58.05782833034289
+ 13
+437292.5129471773
+ 23
+513379.3117220605
+ 14
+-1.425491043350287
+ 24
+54.51436250167302
+ 13
+79990.70901312663
+ 23
+145770.2215585545
+ 14
+-6.574810222091759
+ 24
+51.12159723519859
+ 13
+242388.969440239
+ 23
+70316.88661809862
+ 14
+-4.224307379174182
+ 24
+50.51136094440996
+ 13
+546470.7062785919
+ 23
+726719.9797131164
+ 14
+0.3722511810780964
+ 24
+56.40999474718333
+ 13
+199988.8142809139
+ 23
+52940.78778735036
+ 14
+-4.812368799437513
+ 24
+50.34232908048943
+ 13
+782675.5938960562
+ 23
+542166.0092737493
+ 14
+3.929488694879014
+ 24
+54.62915353351427
+ 13
+780498.7038503255
+ 23
+586818.0966090866
+ 14
+3.954601020434497
+ 24
+55.02991323007477
+ 13
+469262.6567778282
+ 23
+353735.1664058521
+ 14
+-0.9675674911774533
+ 24
+53.07638363749873
+ 13
+761510.5702059263
+ 23
+965742.4814530159
+ 14
+4.193914166390874
+ 24
+58.43001194291758
+ 13
+772163.8262304802
+ 23
+463403.2743046083
+ 14
+3.669624455059366
+ 24
+53.93266971692671
+ 13
+448659.2611408214
+ 23
+278373.8487296025
+ 14
+-1.286221524812475
+ 24
+52.40123874368994
+ 13
+164368.7829324167
+ 23
+335026.394834885
+ 14
+-5.501812185003908
+ 24
+52.86102116669876
+ 13
+93954.39182133662
+ 23
+345060.3597006469
+ 14
+-6.554088700236396
+ 24
+52.91553235513656
+ 13
+322629.1769381498
+ 23
+192402.7044417153
+ 14
+-3.11910077133978
+ 24
+51.6251043200458
+ 13
+352877.1578230942
+ 23
+928818.5492291908
+ 14
+-2.804406685245382
+ 24
+58.24552715788504
+ 13
+111742.2359722112
+ 23
+1007643.672657692
+ 14
+-7.001507219808697
+ 24
+58.85912197961456
+ 13
+270892.2859215807
+ 23
+387665.6559778368
+ 14
+-3.941959580275154
+ 24
+53.37005008263568
+ 13
+178212.8996997499
+ 23
+213645.740267205
+ 14
+-5.216487816644151
+ 24
+51.77743130249057
+ 13
+434632.477235172
+ 23
+1102741.287121885
+ 14
+-1.384461407710178
+ 24
+59.80852676852769
+ 13
+68751.46905094838
+ 23
+581060.2665202409
+ 14
+-7.183796678082403
+ 24
+55.01343713104279
+ 13
+398924.5075631997
+ 23
+385069.9194983202
+ 14
+-2.017623607519829
+ 24
+53.36251710429523
+ 13
+317211.9972776073
+ 23
+557391.8078348276
+ 14
+-3.292659017326142
+ 24
+54.90436424838315
+ 13
+64980.94196372745
+ 23
+865433.8414373514
+ 14
+-7.603692235098746
+ 24
+57.55433654156433
+ 13
+736286.9733867622
+ 23
+1035456.734139786
+ 14
+3.868650768501277
+ 24
+59.07297747666363
+ 13
+375187.9562374849
+ 23
+307600.9970642429
+ 14
+-2.368314389729465
+ 24
+52.66556495076701
+ 13
+594889.5618893448
+ 23
+1074848.16512413
+ 14
+1.442817178231767
+ 24
+59.51421592332292
+ 13
+390782.6888778124
+ 23
+526707.6025833392
+ 14
+-2.14431894539347
+ 24
+54.63541466232483
+ 13
+382412.138341609
+ 23
+1227393.391265145
+ 14
+-2.326319859920852
+ 24
+60.92876265546107
+ 13
+737389.3526691907
+ 23
+598935.829624872
+ 14
+3.297553564575395
+ 24
+55.16942462837601
+ 13
+585009.7096335663
+ 23
+1153085.139933999
+ 14
+1.338155376741465
+ 24
+60.22003072967557
+ 13
+396122.5824479304
+ 23
+65223.44276503338
+ 14
+-2.056007490977318
+ 24
+50.48679600356565
+ 13
+255931.9099684214
+ 23
+891845.8914812351
+ 14
+-4.431977440849027
+ 24
+57.89269256406948
+ 13
+310842.293866925
+ 23
+644769.5732337805
+ 14
+-3.419722567848707
+ 24
+55.68817545847551
+ 13
+196713.4418560295
+ 23
+272163.4545309528
+ 14
+-4.983505751897698
+ 24
+52.30986708827824
+ 13
+675423.9360659595
+ 23
+1201464.316144819
+ 14
+3.030846843021833
+ 24
+60.6017405676841
+ 13
+301475.6135258173
+ 23
+1096443.036227983
+ 14
+-3.754620812305198
+ 24
+59.74168373871448
+ 13
+762950.7599937712
+ 23
+886644.3141433022
+ 14
+4.096356537365116
+ 24
+57.72248633359016
+ 13
+396233.6036404694
+ 23
+901015.5380340876
+ 14
+-2.065400215547124
+ 24
+57.99832972792998
+ 13
+227179.145771292
+ 23
+1213387.399608718
+ 14
+-5.174607325449432
+ 24
+60.76584605291046
+ 13
+508925.2569554436
+ 23
+242017.7172633966
+ 14
+-0.4123923555303332
+ 24
+52.06584344783226
+ 13
+248422.5909015269
+ 23
+443555.6189659957
+ 14
+-4.306620313317499
+ 24
+53.86602838742184
+ 13
+442079.96217199
+ 23
+645186.1073204084
+ 14
+-1.332100769157334
+ 24
+55.6983122641296
+ 13
+710250.0099410057
+ 23
+1273014.965796906
+ 14
+3.778614462500352
+ 24
+61.21552329453052
+ 13
+747086.9439012114
+ 23
+1312389.154976937
+ 14
+4.533204190465197
+ 24
+61.53582985297694
+ 13
+255236.7024534895
+ 23
+200660.2030172581
+ 14
+-4.095544415067105
+ 24
+51.6859910248949
+ 13
+98591.9363693277
+ 23
+224441.8580174851
+ 14
+-6.376925393501795
+ 24
+51.83702553868722
+ 13
+321794.4388362393
+ 23
+854512.0707950214
+ 14
+-3.309237254985355
+ 24
+57.57385935229028
+ 13
+232978.75975567
+ 23
+1291221.678867932
+ 14
+-5.136779416079239
+ 24
+61.46606694686123
+ 13
+129642.647359964
+ 23
+923015.9777202279
+ 14
+-6.592080952956691
+ 24
+58.11319615117883
+ 13
+108014.671897496
+ 23
+798223.0681306461
+ 14
+-6.808023798763032
+ 24
+56.98259435338098
+ 13
+696315.9375147881
+ 23
+475137.6984399957
+ 14
+2.529737994881428
+ 24
+54.08674531346621
+ 13
+73210.95718289019
+ 23
+422592.5049995582
+ 14
+-6.94102159000221
+ 24
+53.59769149196874
+ 13
+24581.61106696352
+ 23
+485876.119281303
+ 14
+-7.74965352641311
+ 24
+54.13111534999693
+ 13
+38925.46038759853
+ 23
+537060.4128202115
+ 14
+-7.593235011800299
+ 24
+54.59921588894462
+ 13
+21205.76135174621
+ 23
+581180.9426154979
+ 14
+-7.923642176754833
+ 24
+54.9806418741592
+ 13
+66115.77198640312
+ 23
+481049.5951867595
+ 14
+-7.111348697453239
+ 24
+54.11656118102437
+ 13
+41271.26516386846
+ 23
+448374.9804570825
+ 14
+-7.451340821822644
+ 24
+53.80751693829988
+ 13
+1583.583876240547
+ 23
+377879.3457357732
+ 14
+-7.961511735067293
+ 24
+53.14850396487304
+ 13
+8533.904721030841
+ 23
+326646.9128508243
+ 14
+-7.796417812647854
+ 24
+52.69549162644462
+ 13
+43368.88761264122
+ 23
+363033.1910868547
+ 14
+-7.323094392844348
+ 24
+53.04523278289658
+ 13
+33642.97676890643
+ 23
+406250.0430262081
+ 14
+-7.517138490150646
+ 24
+53.42534666304754
+ 13
+487988.5639838188
+ 23
+277134.4564850681
+ 14
+-0.7086068320713152
+ 24
+52.38519615514677
+ 13
+620097.7001618094
+ 23
+139687.9549445696
+ 14
+1.143270788660711
+ 24
+51.11419894874169
+ 13
+768301.3199613333
+ 23
+333401.8328390887
+ 14
+3.45992310171636
+ 24
+52.77234571524827
+ 13
+148446.0423727593
+ 23
+702368.3921381454
+ 14
+-6.051535293988066
+ 24
+56.14744089274157
+ 13
+775401.4992061043
+ 23
+1285478.471192295
+ 14
+5.007569291876796
+ 24
+61.26962456920103
+ 13
+787577.7713214856
+ 23
+1244506.940565704
+ 14
+5.149632810767264
+ 24
+60.89281513857911
+ 13
+293158.1462140423
+ 23
+1275935.626492077
+ 14
+-3.999513041095637
+ 24
+61.35023465673095
+ 13
+552630.3425867885
+ 23
+1208614.746421897
+ 14
+0.7970505310108402
+ 24
+60.73142226862592
+ 13
+657594.4794531686
+ 23
+1026701.455393557
+ 14
+2.490324429519342
+ 24
+59.04939093036025
+ 13
+30455.07793023793
+ 23
+1047782.715397888
+ 14
+-8.469427006406906
+ 24
+59.15523743177685
+ 13
+241480.0930254108
+ 23
+680967.2453423755
+ 14
+-4.543190483728375
+ 24
+55.99537976941102
+ 13
+87907.93113665209
+ 23
+295297.1144080108
+ 14
+-6.596556215217215
+ 24
+52.46615681500009
+ 13
+58686.07754598487
+ 23
+1233353.890753668
+ 14
+-8.286485770006358
+ 24
+60.83558251139456
+ 13
+191791.7636019316
+ 23
+1231357.195495247
+ 14
+-5.842000607510636
+ 24
+60.90989317798658
+ 13
+308866.0576190883
+ 23
+1207936.185863963
+ 14
+-3.673490570637926
+ 24
+60.74402479031925
+ 13
+122165.9827043983
+ 23
+1256153.224544949
+ 14
+-7.156772668631574
+ 24
+61.08895004139704
+ 13
+757381.6436236697
+ 23
+1177534.298997037
+ 14
+4.475592627854706
+ 24
+60.32378332175003
+ 13
+797758.3343886982
+ 23
+1158302.286197611
+ 14
+5.163362456062538
+ 24
+60.11496401395607
+ 13
+743928.4763982036
+ 23
+421432.9971532246
+ 14
+3.194730215100491
+ 24
+53.57650902288381
+ 13
+709470.4018624213
+ 23
+216830.0217623345
+ 14
+2.483939960498716
+ 24
+51.76451713265985
+ 13
+472834.6612938695
+ 23
+575445.9515917956
+ 14
+-0.861030085970486
+ 24
+55.06815601189609
+ 13
+620651.6724658346
+ 23
+332725.2316416674
+ 14
+1.275268914194378
+ 24
+52.84682594190476
+ 13
+709565.6409783789
+ 23
+572816.899520763
+ 14
+2.834042698379479
+ 24
+54.9537322041328
+ 13
+611818.2363978888
+ 23
+1224760.187849106
+ 14
+1.897460125928657
+ 24
+60.84905571064894
+ 13
+187421.1986657692
+ 23
+586463.7055829228
+ 14
+-5.335760183731742
+ 24
+55.12681432969771
+ 13
+175710.950238832
+ 23
+768439.5005723401
+ 14
+-5.670395297907469
+ 24
+56.75342096815665
+ 13
+475753.9541296781
+ 23
+205421.0525995269
+ 14
+-0.9042103671272261
+ 24
+51.74238639682813
+ 13
+190547.2632908463
+ 23
+404681.921405398
+ 14
+-5.159241444395125
+ 24
+53.49703398116828
+ 13
+693962.7573219462
+ 23
+372158.2369107127
+ 14
+2.396709363918624
+ 24
+53.16527752749878
+ 13
+83144.04436759161
+ 23
+1262613.376668543
+ 14
+-7.887317191521625
+ 24
+61.11716182155036
+ 13
+201648.8716428527
+ 23
+703145.011303032
+ 14
+-5.197272258712081
+ 24
+56.17951159510212
+ 13
+260840.2468087736
+ 23
+747433.7874582899
+ 14
+-4.268164996445407
+ 24
+56.59807425883591
+ 13
+654907.5270711654
+ 23
+233282.2853128519
+ 14
+1.707262809704398
+ 24
+51.9396166769525
+ 13
+379734.6966948399
+ 23
+459891.5174238594
+ 14
+-2.310901840161064
+ 24
+54.03461713251616
+ 13
+192322.1201009308
+ 23
+1274046.644542963
+ 14
+-5.878866783227426
+ 24
+61.29256710661077
+ 13
+58956.11384237096
+ 23
+-14371.42525052487
+ 14
+-6.728935426944677
+ 24
+49.67433411231695
+ 13
+650694.6615313157
+ 23
+365651.3924416941
+ 14
+1.745932763453642
+ 24
+53.12904446384104
+ 13
+693006.4177719256
+ 23
+654710.6046212835
+ 14
+2.661811563547138
+ 24
+55.69720318622501
+ 13
+509615.4767181463
+ 23
+482642.7500568972
+ 14
+-0.3200432294342312
+ 24
+54.22779575140414
+ 13
+270947.5476960207
+ 23
+704290.1500066908
+ 14
+-4.082401038529855
+ 24
+56.21362329405889
+ 13
+398715.2206554064
+ 23
+1172894.206774823
+ 14
+-2.025186178723957
+ 24
+60.43985745786867
+ 13
+308356.8500526425
+ 23
+272042.1973832073
+ 14
+-3.346519629605155
+ 24
+52.33878955234784
+ 13
+319210.0702973976
+ 23
+912416.2499299957
+ 14
+-3.372067406048388
+ 24
+58.09335498838039
+ 13
+517714.9664373228
+ 23
+413277.6580691301
+ 14
+-0.2225189686234384
+ 24
+53.60287078326408
+ 13
+439323.8878896712
+ 23
+761005.1672359076
+ 14
+-1.358808992453097
+ 24
+56.73903058665261
+ 13
+583818.7980432774
+ 23
+156521.0971978244
+ 14
+0.6341961476471
+ 24
+51.27817564153506
+ 13
+553993.56218113
+ 23
+101125.3726104568
+ 14
+0.1834113283119228
+ 24
+50.78924485455623
+ 13
+70625.59309818229
+ 23
+1297738.723954249
+ 14
+-8.179819085578172
+ 24
+61.42038635108464
+ 13
+590771.0158501143
+ 23
+399779.3490002429
+ 14
+0.8720885030154185
+ 24
+53.46022444853591
+ 13
+362377.8445032821
+ 23
+378231.3847037086
+ 14
+-2.565963638726053
+ 24
+53.29970498732943
+ 13
+34273.43378380597
+ 23
+1304907.947261153
+ 14
+-8.870281294614111
+ 24
+61.45175609267063
+ 13
+5224.29034394517
+ 23
+1275706.865814034
+ 14
+-9.349247150407713
+ 24
+61.16331153471271
+ 13
+437039.0410282491
+ 23
+1174973.878958523
+ 14
+-1.328498941220508
+ 24
+60.4568473863117
+ 13
+221830.1049286894
+ 23
+563200.2977560467
+ 14
+-4.782344110265523
+ 24
+54.93159018832657
+ 13
+541873.6595405226
+ 23
+594221.0146043286
+ 14
+0.2287401296842864
+ 24
+55.22183861167132
+ 13
+626652.4698195302
+ 23
+848099.7286362452
+ 14
+1.777826153752402
+ 24
+57.4664887072945
+ 13
+283073.1238452088
+ 23
+962491.1123689804
+ 14
+-4.010021804764586
+ 24
+58.53474992905847
+ 13
+232552.3942711523
+ 23
+815666.5618474869
+ 14
+-4.77339782565747
+ 24
+57.20107344384703
+ 13
+335526.713267965
+ 23
+1146534.953051776
+ 14
+-3.164692996469971
+ 24
+60.19806769438059
+ 13
+82102.2952255398
+ 23
+638034.2029780848
+ 14
+-7.040162656040253
+ 24
+55.53213133869217
+ 13
+573244.1361657908
+ 23
+278608.5937869377
+ 14
+0.5438021805293358
+ 24
+52.37813159208894
+ 13
+268325.4912411982
+ 23
+1029697.595794577
+ 14
+-4.30279776158338
+ 24
+59.1336203733249
+ 13
+649287.7010097839
+ 23
+698693.6566546093
+ 14
+2.008570017065439
+ 24
+56.11584103894124
+ 13
+258668.2189283683
+ 23
+1263600.803891941
+ 14
+-4.634360730235288
+ 24
+61.22861167022222
+ 13
+69697.63505219884
+ 23
+517393.5449321282
+ 14
+-7.096864196634053
+ 24
+54.44422147797094
+ 13
+379636.4410127362
+ 23
+664488.2386235952
+ 14
+-2.327012911722535
+ 24
+55.87312070547303
+ 13
+426095.7960009696
+ 23
+816895.9673433546
+ 14
+-1.569275139391337
+ 24
+57.24201793980221
+ 13
+441342.7838371485
+ 23
+477195.7649083621
+ 14
+-1.367938520816466
+ 24
+54.18888551447945
+ 13
+358090.8893856241
+ 23
+1260215.552659683
+ 14
+-2.782194580684878
+ 24
+61.22156078144525
+ 13
+369859.2757361617
+ 23
+1300489.284685436
+ 14
+-2.569645970423952
+ 24
+61.58417211649889
+ 13
+680510.2458461606
+ 23
+165346.3542698133
+ 14
+2.024387689641327
+ 24
+51.31800685985108
+ 13
+305287.0640577284
+ 23
+1310100.393983707
+ 14
+-3.79041981035155
+ 24
+61.65992787197048
+ 13
+584310.2445330057
+ 23
+34826.02477165643
+ 14
+0.580430211253776
+ 24
+50.18478908741358
+ 13
+473876.2439727151
+ 23
+825834.1827256888
+ 14
+-0.7750909325110867
+ 24
+57.31708794042978
+ 13
+52868.09002682005
+ 23
+286528.9125889191
+ 14
+-7.101267139463534
+ 24
+52.36650821797659
+ 13
+324141.3786777298
+ 23
+985348.9128507833
+ 14
+-3.312595052946147
+ 24
+58.74908389308095
+ 13
+519542.9705504671
+ 23
+1061028.747997031
+ 14
+0.1047531133052397
+ 24
+59.41845439872545
+ 13
+566545.2552523168
+ 23
+652191.5609670269
+ 14
+0.6508752008539785
+ 24
+55.7344784920121
+ 13
+672815.8526991869
+ 23
+1264879.228673854
+ 14
+3.072858959345885
+ 24
+61.1706555891227
+ 13
+642066.0227055475
+ 23
+1290576.402330136
+ 14
+2.536239782882147
+ 24
+61.42081472694759
+ 13
+581393.9238319466
+ 23
+1300429.598995316
+ 14
+1.411208177865036
+ 24
+61.54222002562671
+ 13
+604050.7801190003
+ 23
+1267814.216638562
+ 14
+1.800771343146882
+ 24
+61.23877704528183
+ 13
+730565.8485300423
+ 23
+639687.3641593075
+ 14
+3.238937801853813
+ 24
+55.53868603907941
+ 13
+419459.5823407843
+ 23
+588172.3031962783
+ 14
+-1.695931119301727
+ 24
+55.18745838883797
+ 13
+463495.9436479261
+ 23
+94197.73614623826
+ 14
+-1.101423988409211
+ 24
+50.74391224791103
+ 13
+593363.4796949665
+ 23
+941717.3899800548
+ 14
+1.299939781312737
+ 24
+58.32138763586925
+ 13
+324403.6734307622
+ 23
+1042296.446114461
+ 14
+-3.327614087228114
+ 24
+59.26040983293764
+ 13
+98753.17154206289
+ 23
+1062462.288338923
+ 14
+-7.301075191843891
+ 24
+59.34042749324067
+ 13
+123777.7896771692
+ 23
+766369.2871396105
+ 14
+-6.514941732945414
+ 24
+56.70702455227688
+ 13
+389885.3531997191
+ 23
+194059.3617586134
+ 14
+-2.147570764732844
+ 24
+51.64524166296374
+ 13
+566697.0929117812
+ 23
+1100651.178327714
+ 14
+0.9657148542112055
+ 24
+59.75775993313632
+ 13
+13859.20050107757
+ 23
+989200.575557907
+ 14
+-8.655988803879708
+ 24
+58.6180019507999
+ 13
+579566.0996087653
+ 23
+712867.1537224983
+ 14
+0.8984779898502671
+ 24
+56.27429347644916
+ 13
+764003.4968903662
+ 23
+1104508.329246637
+ 14
+4.465790918118696
+ 24
+59.66645928809132
+ 13
+57776.72483150675
+ 23
+938409.054935826
+ 14
+-7.828358144333221
+ 24
+58.20107489733548
+ 13
+374488.5170527775
+ 23
+744341.2570015744
+ 14
+-2.417005661011049
+ 24
+56.59027569409068
+ 13
+634192.9316131768
+ 23
+740321.1231082635
+ 14
+1.803287748163872
+ 24
+56.49663624394102
+ 13
+375030.4638974153
+ 23
+1034472.556023372
+ 14
+-2.438842101473259
+ 24
+59.19618359475534
+ 13
+560151.643428829
+ 23
+437299.7172101934
+ 14
+0.4306569204243704
+ 24
+53.80735268342871
+ 13
+34153.8916098652
+ 23
+244694.3755129459
+ 14
+-7.329876214944454
+ 24
+51.97987854137238
+ 13
+171267.2102681808
+ 23
+818432.1551346087
+ 14
+-5.788202935211439
+ 24
+57.19938348870598
+ 13
+704456.6854905093
+ 23
+1068101.495954387
+ 14
+3.361664211872352
+ 24
+59.38875349052096
+ 13
+224346.0038216293
+ 23
+374732.8428370581
+ 14
+-4.633687571700146
+ 24
+53.24049979572748
+ 13
+165064.6967557128
+ 23
+1172134.108221149
+ 14
+-6.262689657543223
+ 24
+60.3647237400914
+ 13
+146217.7461847026
+ 23
+1138265.158171394
+ 14
+-6.560906463222892
+ 24
+60.05022727301544
+ 13
+256608.8175660257
+ 23
+501922.8698796662
+ 14
+-4.209964761660062
+ 24
+54.39253827910635
+ 13
+622846.6984215977
+ 23
+1018392.916100304
+ 14
+1.877732907984566
+ 24
+58.99450632246094
+ 13
+630361.2052334906
+ 23
+275312.5146181876
+ 14
+1.37928964984593
+ 24
+52.32753703469385
+ 13
+698243.6472078089
+ 23
+754008.8148084921
+ 14
+2.855875874438792
+ 24
+56.58302741252186
+ 13
+748299.9739517932
+ 23
+37888.19184081933
+ 14
+2.873556007842665
+ 24
+50.13866934178634
+ 13
+238450.221169807
+ 23
+-4648.828782732416
+ 14
+-4.247931628369538
+ 24
+49.8366191342373
+ 13
+280728.2994708181
+ 23
+852029.4655990827
+ 14
+-3.994244174112629
+ 24
+57.54259329677528
+ 13
+356479.29138847
+ 23
+1480.004979200792
+ 14
+-2.607487956858797
+ 24
+49.91194966515709
+ 13
+572462.7686011196
+ 23
+880168.3796914046
+ 14
+0.8985476393169287
+ 24
+57.77798419512685
+ 13
+630462.0775557769
+ 23
+639664.4798891946
+ 14
+1.656324764794816
+ 24
+55.59600353692527
+ 13
+756726.4424676764
+ 23
+662277.9468362779
+ 14
+3.680717796011661
+ 24
+55.72228669970956
+ 13
+799820.7187361112
+ 23
+721347.2755379086
+ 14
+4.45012624049657
+ 24
+56.21613632407966
+ 13
+759182.1788732167
+ 23
+705740.823315642
+ 14
+3.777295226534481
+ 24
+56.10901620403628
+ 13
+767845.0130379009
+ 23
+746953.8400546629
+ 14
+3.97319390698718
+ 24
+56.47071154512469
+ 13
+791573.1482702752
+ 23
+682109.8558663587
+ 14
+4.260723005681709
+ 24
+55.87257462254083
+ 13
+279448.860149309
+ 23
+-35420.19146379126
+ 14
+-3.668578067285865
+ 24
+49.56962678590183
+ 13
+272183.7931117304
+ 23
+-78468.05070409948
+ 14
+-3.755165356194372
+ 24
+49.18111245129961
+ 13
+237068.4831629185
+ 23
+-77572.59453125752
+ 14
+-4.237025220542603
+ 24
+49.18083510875863
+ 13
+619624.6616400748
+ 23
+208194.9558788062
+ 14
+1.178947924278927
+ 24
+51.72943733269171
+ 13
+676707.3991623158
+ 23
+526830.4369940532
+ 14
+2.278724567009868
+ 24
+54.56093591369071
+ 13
+782360.1817028142
+ 23
+-52472.54653928219
+ 14
+3.25979452531489
+ 24
+49.30848496531218
+ 13
+497415.8682696751
+ 23
+10300.95695289195
+ 14
+-0.6424799611526348
+ 24
+49.98493526379475
+ 13
+500430.8809706732
+ 23
+1118538.66416758
+ 14
+-0.2044222134105062
+ 24
+59.93960536923943
+ 13
+316689.2964978329
+ 23
+1250898.893938465
+ 14
+-3.548681138762516
+ 24
+61.13131289347816
+ 13
+758557.2316737553
+ 23
+260736.6449122381
+ 14
+3.238148231463635
+ 24
+52.1284061192757
+ 13
+792017.3868339685
+ 23
+272142.1699828704
+ 14
+3.737717895277238
+ 24
+52.20775532758214
+ 13
+800533.4928680857
+ 23
+310659.646096314
+ 14
+3.907634625681444
+ 24
+52.54609229469821
+ 13
+488878.9975267453
+ 23
+142874.5875167011
+ 14
+-0.7298690016019448
+ 24
+51.17820463693739
+ 13
+435313.0177555557
+ 23
+246970.5364872556
+ 14
+-1.485649268872795
+ 24
+52.11994317602416
+ 13
+756038.7792661964
+ 23
+365169.9384820886
+ 14
+3.313738421492073
+ 24
+53.06491133376749
+ 13
+709759.0335935676
+ 23
+182780.618663707
+ 14
+2.458052241647778
+ 24
+51.45914304233284
+ 13
+498443.3837951727
+ 23
+336202.0227298258
+ 14
+-0.5374509650473617
+ 24
+52.91425459770244
+ 13
+166152.0927546541
+ 23
+49548.23469100593
+ 14
+-5.285045110401004
+ 24
+50.29940906755798
+ 13
+677026.4746158827
+ 23
+594885.6647428989
+ 14
+2.348902927730799
+ 24
+55.17059419700903
+ 13
+556606.7481581717
+ 23
+1033358.964648016
+ 14
+0.7370892145319811
+ 24
+59.15811754935781
+ 13
+784058.8456644853
+ 23
+818492.4426390102
+ 14
+4.342087629805284
+ 24
+57.09660249494238
+ 13
+378257.1312125299
+ 23
+266945.3203035028
+ 14
+-2.320264545037455
+ 24
+52.30020924214951
+ 13
+207555.7860588175
+ 23
+1064150.190213737
+ 14
+-5.393603550572708
+ 24
+59.41930595138353
+ 13
+656771.4581306233
+ 23
+913232.6557143215
+ 14
+2.348121282971515
+ 24
+58.03384121857985
+ 13
+724507.8339897633
+ 23
+846684.6668789138
+ 14
+3.400671540679716
+ 24
+57.39454347926983
+ 13
+266252.964669604
+ 23
+814108.8970936964
+ 14
+-4.21525077650909
+ 24
+57.198172605618
+ 13
+751704.2426243974
+ 23
+227717.8642709647
+ 14
+3.104633684521683
+ 24
+51.83712788556793
+ 13
+586953.8487130199
+ 23
+331654.4095742493
+ 14
+0.7749343372273217
+ 24
+52.84995148735637
+ 13
+326595.627425179
+ 23
+-25733.25509653428
+ 14
+-3.018484186672583
+ 24
+49.66430634536579
+ 13
+426428.1356962867
+ 23
+932195.7549822784
+ 14
+-1.551111142080688
+ 24
+58.27761258656558
+ 13
+646416.4205901347
+ 23
+64231.48106635243
+ 14
+1.468084435100263
+ 24
+50.42620523901228
+ 13
+663193.1894317602
+ 23
+102670.7004043502
+ 14
+1.730978446378048
+ 24
+50.76388576175664
+ 13
+179512.817991324
+ 23
+1107516.545896218
+ 14
+-5.931794111269534
+ 24
+59.79404410531589
+ 13
+714012.8273237877
+ 23
+1306413.306449462
+ 14
+3.904417843536456
+ 24
+61.51077085168317
+ 13
+517907.116666133
+ 23
+1184180.470408868
+ 14
+0.1462883668583721
+ 24
+60.52395988426399
+ 13
+370813.0015453882
+ 23
+1098950.568276877
+ 14
+-2.521531196377527
+ 24
+59.77488855511549
+ 13
+221855.8896774588
+ 23
+1175711.189609095
+ 14
+-5.238125462230441
+ 24
+60.42578035126117
+ 13
+376322.4055319792
+ 23
+859834.632537162
+ 14
+-2.398122737271597
+ 24
+57.62782714799511
+ 13
+218936.9518612684
+ 23
+341679.7205427261
+ 14
+-4.696018912711496
+ 24
+52.9418988851231
+ 13
+350771.832447588
+ 23
+53163.01274987598
+ 14
+-2.69365826550078
+ 24
+50.37628092701069
+ 13
+330511.2184481362
+ 23
+811220.4819923144
+ 14
+-3.151282117433805
+ 24
+57.18649300150327
+ 13
+633119.7513237978
+ 23
+-35704.26849449289
+ 14
+1.220647784230261
+ 24
+49.53427457477274
+ 13
+418337.4412536553
+ 23
+412245.8543422762
+ 14
+-1.724341166874593
+ 24
+53.60647022170058
+ 13
+686947.3126129225
+ 23
+-51088.27099970297
+ 14
+1.95178009372022
+ 24
+49.37316087775591
+ 13
+723168.9537662302
+ 23
+-56157.40442586362
+ 14
+2.445179277647619
+ 24
+49.30960603703481
+ 13
+753911.657315415
+ 23
+-72741.0974487836
+ 14
+2.852031812307177
+ 24
+49.14395616563117
+ 13
+693131.3302306524
+ 23
+42722.6528601669
+ 14
+2.107419509453865
+ 24
+50.21184685624707
+ 13
+26654.2258425161
+ 23
+1242590.824370274
+ 14
+-8.889303261558005
+ 24
+60.88914495638212
+ 13
+687117.0545258462
+ 23
+-748.1248851144883
+ 14
+1.990861284571274
+ 24
+49.82477234483035
+ 13
+566173.1464311603
+ 23
+1270800.88251434
+ 14
+1.098878656050682
+ 24
+61.2834810841738
+ 13
+538337.1771278437
+ 23
+1303824.639909512
+ 14
+0.6047412718419439
+ 24
+61.59048997770294
+ 13
+424143.5192450508
+ 23
+130093.6474761208
+ 14
+-1.656785353636811
+ 24
+51.06966409878307
+ 13
+253590.1879962651
+ 23
+553257.7181802146
+ 14
+-4.282081325397159
+ 24
+54.85264747904455
+ 13
+241570.4653860717
+ 23
+1112179.789091842
+ 14
+-4.831099655143735
+ 24
+59.86426977443514
+ 13
+307291.5035624858
+ 23
+1129109.011387084
+ 14
+-3.665818088617422
+ 24
+60.03621613500125
+ 13
+558620.7733667202
+ 23
+531314.5800224519
+ 14
+0.4570653144358405
+ 24
+54.65198987267807
+ 13
+617195.8405636327
+ 23
+1160872.429469178
+ 14
+1.92608964125546
+ 24
+60.27392118934828
+ 13
+275475.2712875052
+ 23
+1158817.934465455
+ 14
+-4.254625680141383
+ 24
+60.29433185399884
+ 13
+646929.0726871062
+ 23
+1218261.139804548
+ 14
+2.533324505792015
+ 24
+60.77061482200274
+ 13
+18513.8879022394
+ 23
+614111.2567786873
+ 14
+-8.00965929527409
+ 24
+55.27288399651786
+ 13
+348562.3512781914
+ 23
+567644.3500736313
+ 14
+-2.805644913780484
+ 24
+55.00070438537882
+ 13
+61981.09075302361
+ 23
+1075466.02900869
+ 14
+-7.964548488782082
+ 24
+59.42873510312839
+ 13
+323875.1956805462
+ 23
+302700.9960317408
+ 14
+-3.125809713050499
+ 24
+52.61673660959741
+ 13
+671134.9059549824
+ 23
+630071.4664733036
+ 14
+2.290658792696399
+ 24
+55.48914249708351
+ 13
+406951.174849186
+ 23
+316320.9843100525
+ 14
+-1.898465172305822
+ 24
+52.74448639055956
+ 13
+788172.645799054
+ 23
+1126829.865041068
+ 14
+4.933010963026874
+ 24
+59.84365240137805
+ 13
+126338.7092630466
+ 23
+242112.5252854755
+ 14
+-5.989274276271755
+ 24
+52.00980225702499
+ 13
+543510.5314118388
+ 23
+-16184.38594921004
+ 14
+-0.0096822500887661
+ 24
+49.73757784497244
+ 13
+582936.0599484211
+ 23
+-29892.78581765172
+ 14
+0.5305622744521016
+ 24
+49.6037151465409
+ 13
+259879.9564672857
+ 23
+1216622.306645136
+ 14
+-4.577393391951431
+ 24
+60.80771429543013
+ 13
+712132.4014266264
+ 23
+1106311.751651356
+ 14
+3.552266335849342
+ 24
+59.72466045313347
+ 13
+128458.234533439
+ 23
+480058.2762940614
+ 14
+-6.15944694108835
+ 24
+54.14438090711755
+ 13
+159377.7697268549
+ 23
+377488.379198985
+ 14
+-5.607508814868434
+ 24
+53.23975605035094
+ 13
+547147.1212368249
+ 23
+53050.97021569628
+ 14
+0.0673470683651635
+ 24
+50.3589788938278
+ 13
+158191.8453469748
+ 23
+866702.7354325549
+ 14
+-6.051633601085541
+ 24
+57.62519863597376
+ 13
+731898.3123331246
+ 23
+490261.7466261611
+ 14
+3.088242050518869
+ 24
+54.20046563694738
+ 13
+693561.340860931
+ 23
+245319.0097682871
+ 14
+2.278300844840646
+ 24
+52.02850571977773
+ 13
+55819.07054709738
+ 23
+1107487.817389249
+ 14
+-8.124463396431185
+ 24
+59.70965842570119
+ 13
+118987.0933821882
+ 23
+1203508.645443312
+ 14
+-7.139101626314644
+ 24
+60.61596504320985
+ 13
+257146.512080642
+ 23
+233087.2741794667
+ 14
+-4.081328699247332
+ 24
+51.9778433271459
+ 13
+716039.9249703281
+ 23
+706368.2529410972
+ 14
+3.087208914696579
+ 24
+56.14509357789883
+ 13
+404175.6404195512
+ 23
+1113791.279384231
+ 14
+-1.927146567153513
+ 24
+59.9091646653818
+ 13
+234720.8098416201
+ 23
+916332.8692059669
+ 14
+-4.806484559419081
+ 24
+58.10501340868547
+ 13
+443282.4074185836
+ 23
+-8285.116794517279
+ 14
+-1.399604377932184
+ 24
+49.82416591930547
+ 13
+52184.78930885777
+ 23
+831201.3189360099
+ 14
+-7.767998688300707
+ 24
+57.23875775449513
+ 13
+175435.6674374601
+ 23
+639545.0078045855
+ 14
+-5.565953972917854
+ 24
+55.59757467827485
+ 13
+635168.5374734751
+ 23
+394024.3188257244
+ 14
+1.535289322416795
+ 24
+53.39066596136341
+ 13
+673568.9360664181
+ 23
+431087.7100567288
+ 14
+2.143633501879719
+ 24
+53.70445568645976
+ 13
+668496.9765660622
+ 23
+491564.6252909934
+ 14
+2.120233478052437
+ 24
+54.24924547604647
+ 13
+104702.0957146123
+ 23
+854940.5183995366
+ 14
+-6.929778648232068
+ 24
+57.48811375126148
+ 13
+338550.8612145664
+ 23
+1195635.377659981
+ 14
+-3.125284865810787
+ 24
+60.63929885363073
+ 13
+150351.8465276488
+ 23
+11669.53316556696
+ 14
+-5.48170622287135
+ 24
+49.9528990475158
+ 13
+441024.9928565918
+ 23
+692456.1785220446
+ 14
+-1.341729046399576
+ 24
+56.12308363229806
+ 13
+196157.085868703
+ 23
+240155.9913630371
+ 14
+-4.972432481315018
+ 24
+52.02228865767548
+ 13
+96623.13865834677
+ 23
+711007.7811242948
+ 14
+-6.892586829006202
+ 24
+56.19466381607609
+ 13
+170439.1387115137
+ 23
+521706.0290040071
+ 14
+-5.550169501469722
+ 24
+54.53844061161205
+ 13
+75100.58722965176
+ 23
+799181.8567146798
+ 14
+-7.348511604779333
+ 24
+56.96922489310779
+ 13
+324184.9627800074
+ 23
+1074131.506483857
+ 14
+-3.342717658874131
+ 24
+59.54617011669778
+ 13
+101975.7258416507
+ 23
+40144.16054962842
+ 14
+-6.176545872484908
+ 24
+50.1861458939303
+ 13
+701916.0753064776
+ 23
+1003293.819829094
+ 14
+3.227931263210974
+ 24
+58.81105556550941
+ 13
+127335.3441878573
+ 23
+1076167.588797659
+ 14
+-6.817856432118424
+ 24
+59.48251875726219
+ 13
+437525.1670562321
+ 23
+308030.7123205486
+ 14
+-1.446524511429605
+ 24
+52.66871287584816
+ 13
+338920.2095852354
+ 23
+671370.7607798712
+ 14
+-2.979188510902782
+ 24
+55.93149996277998
+ 13
+718479.4291367627
+ 23
+542458.0998854705
+ 14
+2.939355750622405
+ 24
+54.67633081814631
+ 13
+679119.9014758404
+ 23
+306892.3855602469
+ 14
+2.119374149763743
+ 24
+52.58809832444463
+ 13
+265573.4178624508
+ 23
+324057.5672124862
+ 14
+-3.995239086336009
+ 24
+52.79729807532451
+ 13
+19389.80970318463
+ 23
+1194875.555865515
+ 14
+-8.929694530117899
+ 24
+60.45702384229181
+ 13
+36644.64944229514
+ 23
+1167405.684792674
+ 14
+-8.568464640721503
+ 24
+60.22791427553078
+ 13
+732673.6243482717
+ 23
+952802.273515695
+ 14
+3.683934929013432
+ 24
+58.33723563644992
+ 13
+422518.3834042058
+ 23
+175181.8168372642
+ 14
+-1.677151703791482
+ 24
+51.47515363541777
+ 13
+606654.2689983119
+ 23
+73504.78693953011
+ 14
+0.9142206213160305
+ 24
+50.52482208455009
+ 13
+148786.7363077761
+ 23
+747109.41859026
+ 14
+-6.088816595580498
+ 24
+56.5485647626256
+ 13
+507294.4580602793
+ 23
+205962.4090296336
+ 14
+-0.4473872924358526
+ 24
+51.74210950797354
+ 13
+411383.7276849144
+ 23
+1239856.774015472
+ 14
+-1.791148187370285
+ 24
+61.04088746607426
+ 13
+758388.6665878243
+ 23
+1012962.132492307
+ 14
+4.215522068463742
+ 24
+58.85418815484005
+ 13
+462414.3992109067
+ 23
+984873.7027730619
+ 14
+-0.9232576251937516
+ 24
+58.74701769134399
+ 13
+82680.95623219446
+ 23
+907335.4176945493
+ 14
+-7.364610456702735
+ 24
+57.94182990933611
+ 13
+530523.3417633965
+ 23
+545511.2842514822
+ 14
+0.0282494563694807
+ 24
+54.78753650610151
+ 13
+484143.9172642598
+ 23
+464194.6619618101
+ 14
+-0.7157789426123186
+ 24
+54.06684757039506
+ 13
+514232.5197387775
+ 23
+750221.5211525491
+ 14
+-0.1395696538826386
+ 24
+56.62990430490468
+ 13
+33933.06650056406
+ 23
+718701.6934251116
+ 14
+-7.908339018632891
+ 24
+56.21942466117509
+ 13
+592384.7525037793
+ 23
+575452.4778545315
+ 14
+1.009021900287696
+ 24
+55.03634940947751
+ 13
+499099.8106356829
+ 23
+512173.0942679323
+ 14
+-0.4714676501884638
+ 24
+54.49522966170234
+ 13
+160689.9413414578
+ 23
+1046458.289886692
+ 14
+-6.197660081985352
+ 24
+59.23681067247927
+ 13
+113682.2417734423
+ 23
+1113495.313392326
+ 14
+-7.108552745102168
+ 24
+59.80729793943357
+ 13
+199623.1003639055
+ 23
+473405.0835512642
+ 14
+-5.06736122453517
+ 24
+54.11737695564227
+ 13
+374936.8870322521
+ 23
+781180.0961454015
+ 14
+-2.413326312727974
+ 24
+56.92123269240035
+ 13
+646562.3805132086
+ 23
+544832.0854545354
+ 14
+1.828794008392192
+ 24
+54.73792174869656
+ 13
+175286.7744908901
+ 23
+686362.0931794372
+ 14
+-5.606981128466926
+ 24
+56.0173232279468
+ 13
+476305.8411114509
+ 23
+730006.5297465882
+ 14
+-0.7635230663921396
+ 24
+56.45604105571425
+ 13
+785937.1959141758
+ 23
+651482.2251151603
+ 14
+4.127993192439925
+ 24
+55.60350682298806
+ 13
+799342.4862315331
+ 23
+617794.0277943037
+ 14
+4.291227652623999
+ 24
+55.29184884012482
+ 13
+101209.0282863151
+ 23
+967136.8981817163
+ 14
+-7.129728251784524
+ 24
+58.48962241009537
+ 13
+628059.1579013177
+ 23
+675939.9554569679
+ 14
+1.648558109114319
+ 24
+55.92241329725553
+ 13
+465741.0238211174
+ 23
+1039136.07229141
+ 14
+-0.849658293707781
+ 24
+59.23372953218128
+ 13
+29488.00688172403
+ 23
+925744.4738202236
+ 14
+-8.286748472468335
+ 24
+58.06518657364613
+ 13
+14593.98204260066
+ 23
+889013.765971733
+ 14
+-8.478068918845822
+ 24
+57.72472109548175
+ 13
+556814.5206275266
+ 23
+1140252.734691172
+ 14
+0.8200511930529707
+ 24
+60.11676876376002
+ 13
+300295.3514556299
+ 23
+452795.4419150136
+ 14
+-3.52115447603419
+ 24
+53.96160836720816
+ 13
+294363.5882870152
+ 23
+20920.00941809941
+ 14
+-3.47775716112352
+ 24
+50.0789606327725
+ 13
+216171.3867837341
+ 23
+841876.3679337731
+ 14
+-5.063648931641486
+ 24
+57.4298963775081
+ 13
+311914.2279219158
+ 23
+412628.1725530961
+ 14
+-3.332633144593059
+ 24
+53.60280047401236
+ 13
+185743.9863336322
+ 23
+880842.7110379604
+ 14
+-5.603861424527199
+ 24
+57.76589128586544
+ 13
+562648.0808093923
+ 23
+944751.6919302598
+ 14
+0.7783926819472811
+ 24
+58.36104642424173
+ 13
+619086.4972867963
+ 23
+593685.9100313456
+ 14
+1.44012135519919
+ 24
+55.18886367912728
+ 13
+512386.3221844453
+ 23
+928770.1136234707
+ 14
+-0.0877961051841548
+ 24
+58.23333645347919
+ 13
+454076.752239793
+ 23
+46239.32870473574
+ 14
+-1.241854862861725
+ 24
+50.3136110009224
+ 13
+514459.6061486424
+ 23
+1284327.098121193
+ 14
+0.143160384011274
+ 24
+61.42341307603868
+ 13
+67458.71893585898
+ 23
+1166695.447228963
+ 14
+-8.014169575489276
+ 24
+60.24789600387805
+ 13
+612063.6563374273
+ 23
+1297557.689392016
+ 14
+1.983465921285394
+ 24
+61.50088741376453
+ 13
+736365.7859517957
+ 23
+282087.6222219511
+ 14
+2.936422208651626
+ 24
+52.33358554708599
+ 13
+619252.5656285013
+ 23
+530643.7933826925
+ 14
+1.394775235508627
+ 24
+54.62328548631697
+ 13
+600219.0357438034
+ 23
+909358.5676037717
+ 14
+1.389021206777398
+ 24
+58.02819770195098
+ 13
+288528.7787731087
+ 23
+913591.0099715859
+ 14
+-3.892767162557576
+ 24
+58.09723558685064
+ 13
+647707.2363860982
+ 23
+578127.6266180189
+ 14
+1.875106918992839
+ 24
+55.03588492280492
+ 13
+123417.4167474573
+ 23
+90210.13711687626
+ 14
+-5.913815116247516
+ 24
+50.64576259600299
+ 13
+753185.5720775957
+ 23
+857567.1408525183
+ 14
+3.890998744373308
+ 24
+57.47046553480955
+ 13
+648556.3879695871
+ 23
+792460.3427031627
+ 14
+2.08647644930867
+ 24
+56.95651574737722
+ 13
+216773.1401585212
+ 23
+166921.4855858688
+ 14
+-4.633834438786558
+ 24
+51.37171525221495
+ 13
+462452.1228076203
+ 23
+1090029.303766089
+ 14
+-0.8924398052826134
+ 24
+59.69115226620947
+ 13
+28598.5483105184
+ 23
+-10793.73401993518
+ 14
+-7.151431638414083
+ 24
+49.68846429678716
+ 13
+717396.3186292976
+ 23
+1215858.321808857
+ 14
+3.816691664678381
+ 24
+60.69934812320838
+ 13
+379956.335133632
+ 23
+1196970.679826942
+ 14
+-2.368471857121135
+ 24
+60.65551604925524
+ 13
+46852.03355513873
+ 23
+980417.2842212221
+ 14
+-8.077630228047265
+ 24
+58.56765681219212
+ 13
+284215.113287486
+ 23
+1190004.56361471
+ 14
+-4.11474867756984
+ 24
+60.57673908316638
+ 13
+95220.47241807493
+ 23
+-13108.13779417442
+ 14
+-6.228747221403664
+ 24
+49.70508589089409
+ 13
+511980.7269327532
+ 23
+647254.4605834443
+ 14
+-0.2195709272493499
+ 24
+55.70581053593856
+ 13
+462502.8138528604
+ 23
+406519.6971675227
+ 14
+-1.058080325499635
+ 24
+53.55161675558633
+ 13
+82621.82028097514
+ 23
+1016175.248888826
+ 14
+-7.516186393753661
+ 24
+58.91489057587997
+ 13
+434083.3366877644
+ 23
+101471.7536242341
+ 14
+-1.517598842938464
+ 24
+50.81178989622769
+ 13
+415537.6715813935
+ 23
+877687.415172795
+ 14
+-1.740357142822286
+ 24
+57.78854966876625
+ 13
+409408.8160779164
+ 23
+966787.5039309137
+ 14
+-1.839877641347372
+ 24
+58.58897510699655
+ 13
+427877.2457926825
+ 23
+991208.6855476891
+ 14
+-1.519205105927671
+ 24
+58.80750551472609
+ 13
+211742.9929978927
+ 23
+9498.221837026671
+ 14
+-4.625889852539081
+ 24
+49.95591233942647
+ 13
+386683.5341457086
+ 23
+2486.943800039953
+ 14
+-2.186850295414332
+ 24
+49.92244306515805
+ 13
+769781.5433100092
+ 23
+121365.5720356465
+ 14
+3.255489639505624
+ 24
+50.87329010349586
+ 13
+793997.2956201231
+ 23
+143114.1702398263
+ 14
+3.62154926918021
+ 24
+51.051949348295
+ 13
+494204.2227324928
+ 23
+1239560.626561264
+ 14
+-0.2585540586927273
+ 24
+61.02716012800883
+ 13
+601253.7060126819
+ 23
+267447.6595372793
+ 14
+0.9480842897071768
+ 24
+52.26836054893954
+ 13
+526330.8975014531
+ 23
+1031673.501940551
+ 14
+0.207141608092037
+ 24
+59.15305999958341
+ 13
+455178.494015628
+ 23
+923221.4194872234
+ 14
+-1.063112119458018
+ 24
+58.19436448873437
+ 13
+328686.5358757389
+ 23
+883829.4396816143
+ 14
+-3.202734397865884
+ 24
+57.83827792709478
+ 13
+510297.1537782597
+ 23
+51185.79757372665
+ 14
+-0.451024383237514
+ 24
+50.35026017077586
+ 13
+423899.2098013717
+ 23
+786865.2893660078
+ 14
+-1.608525745284425
+ 24
+56.97237653645604
+ 13
+32876.78966309582
+ 23
+308992.3690214134
+ 14
+-7.418279522212252
+ 24
+52.55453674668678
+ 13
+632475.1763572812
+ 23
+895536.3666395276
+ 14
+1.920351831799513
+ 24
+57.88865094933276
+ 13
+226455.9048295228
+ 23
+276494.9269503065
+ 14
+-4.549947178117911
+ 24
+52.35897847669455
+ 13
+653982.6429736324
+ 23
+762917.4508430425
+ 14
+2.146069707469453
+ 24
+56.68887442406714
+ 13
+522041.6919920197
+ 23
+1090905.545586764
+ 14
+0.1658940334319465
+ 24
+59.68583168896581
+ 13
+481701.0268673982
+ 23
+-15210.80206280944
+ 14
+-0.8670310008480605
+ 24
+49.75789220596759
+ 13
+490563.0627276963
+ 23
+-46067.68328155355
+ 14
+-0.7511346595994262
+ 24
+49.47915177269035
+ 13
+522641.0235693061
+ 23
+-51779.04570382083
+ 14
+-0.3102532479157936
+ 24
+49.42217638338887
+ 13
+446508.1465671916
+ 23
+1203386.378675135
+ 14
+-1.149704059990442
+ 24
+60.71093890314987
+ 13
+412159.5943734004
+ 23
+644259.3640846888
+ 14
+-1.808154577030861
+ 24
+55.69165029659215
+ 13
+219542.4886085504
+ 23
+451153.2983794569
+ 14
+-4.74978144342697
+ 24
+53.92499746180238
+ 13
+108225.5085820824
+ 23
+571428.2516726237
+ 14
+-6.558762444758664
+ 24
+54.95186906017742
+ 13
+449754.9514262797
+ 23
+220079.5895368347
+ 14
+-1.278626275304367
+ 24
+51.87707999917065
+ 13
+738182.0945776181
+ 23
+133130.095621463
+ 14
+2.818946058349009
+ 24
+50.99804220519823
+ 13
+736843.3629732905
+ 23
+166145.626018961
+ 14
+2.830788816354925
+ 24
+51.29465352710644
+ 13
+316714.1297308428
+ 23
+753649.2751215888
+ 14
+-3.360522743148898
+ 24
+56.6671611326698
+ 13
+76020.45419073486
+ 23
+689449.865486403
+ 14
+-7.197122855742446
+ 24
+55.98822186321503
+ 13
+539163.7053859651
+ 23
+485668.0967232145
+ 14
+0.1343109866365828
+ 24
+54.24779856461992
+ 13
+540673.4760071724
+ 23
+919790.644108578
+ 14
+0.3880781868561094
+ 24
+58.14464722676005
+ 13
+85715.59520232508
+ 23
+738608.3240950014
+ 14
+-7.100576402835144
+ 24
+56.43458236056767
+ 13
+566026.4601216442
+ 23
+622534.4314780174
+ 14
+0.6247790231583493
+ 24
+55.46846357088635
+ 13
+478111.0631380366
+ 23
+1010021.388480202
+ 14
+-0.6433068541274219
+ 24
+58.97024993663327
+ 13
+5330.856273347279
+ 23
+-29159.14719873913
+ 14
+-7.454147914616467
+ 24
+49.50925627420926
+ 13
+585514.0470614352
+ 23
+683831.9904429109
+ 14
+0.9741929366675625
+ 24
+56.01149926551853
+ 13
+562308.6958381629
+ 23
+136139.5261853441
+ 14
+0.3168713251111856
+ 24
+51.10158381405162
+ 13
+680715.2759558857
+ 23
+811259.2784549708
+ 14
+2.634512922839053
+ 24
+57.10647491444579
+ 13
+500348.1982412818
+ 23
+437268.5382008639
+ 14
+-0.4770994895466042
+ 24
+53.82203291333173
+ 13
+538254.4904687502
+ 23
+660868.8973425389
+ 14
+0.2051170616873839
+ 24
+55.82127741969568
+ 13
+257365.580578623
+ 23
+413976.9628579233
+ 14
+-4.157080198416309
+ 24
+53.60290052642511
+ 13
+530702.831156811
+ 23
+701786.0566774533
+ 14
+0.104562217936694
+ 24
+56.19075720687705
+ 13
+636023.8227607631
+ 23
+20322.92328296222
+ 14
+1.294727989403401
+ 24
+50.0362410458168
+ 13
+158949.1366856931
+ 23
+553420.4064672638
+ 14
+-5.753549886538092
+ 24
+54.81749955169598
+ 13
+300546.6774282238
+ 23
+-12076.76144524473
+ 14
+-3.38282974966464
+ 24
+49.78336271115075
+ 13
+337772.0464804032
+ 23
+-52894.92952081563
+ 14
+-2.859337694179423
+ 24
+49.42128703006764
+ 13
+522971.5348120084
+ 23
+979744.1288192189
+ 14
+0.1196928485268582
+ 24
+58.68801269062783
+ 13
+253909.4451255682
+ 23
+959074.6881395428
+ 14
+-4.508243100761396
+ 24
+58.49528422242799
+ 13
+391183.3994181936
+ 23
+691424.4253583075
+ 14
+-2.143374526327547
+ 24
+56.11548293731245
+ 13
+631092.4154210939
+ 23
+455303.1247178534
+ 14
+1.519668395841925
+ 24
+53.94221576462054
+ 13
+356004.7883423482
+ 23
+247929.1803629977
+ 14
+-2.644090289298505
+ 24
+52.12791871954678
+ 13
+523652.5317940287
+ 23
+159720.1738708723
+ 14
+-0.2268004990565125
+ 24
+51.32315220672709
+ 13
+566876.6653678041
+ 23
+213411.2023253942
+ 14
+0.418467944682656
+ 24
+51.79446450020137
+ 13
+217120.721824649
+ 23
+-48414.90008026402
+ 14
+-4.523840992094768
+ 24
+49.43722708145496
+ 13
+688155.1583346151
+ 23
+132773.6893467287
+ 14
+2.10772638586777
+ 24
+51.02205551653898
+ 13
+581190.2298026499
+ 23
+1049082.066937676
+ 14
+1.179407166777817
+ 24
+59.28933961269368
+ 13
+503845.915905978
+ 23
+956670.6587649532
+ 14
+-0.220593954885904
+ 24
+58.48589289334866
+ 13
+662090.5085233231
+ 23
+850589.7264625811
+ 14
+2.369581647700802
+ 24
+57.46973112068157
+ 13
+492622.6548021332
+ 23
+1198701.454686701
+ 14
+-0.307294128118281
+ 24
+60.66088227883684
+ 13
+411531.5227460969
+ 23
+547191.1875086826
+ 14
+-1.822076937231586
+ 24
+54.81944773754944
+ 13
+761049.2069842405
+ 23
+490352.2648519514
+ 14
+3.533177470151912
+ 24
+54.18161149852767
+ 13
+47109.04941676587
+ 23
+692755.7552578871
+ 14
+-7.662656959374792
+ 24
+55.99741442369154
+ 13
+529535.0735899223
+ 23
+386693.4323247054
+ 14
+-0.0549491827114106
+ 24
+53.3612756186908
+ 13
+619267.8602186479
+ 23
+954933.7162599774
+ 14
+1.753804053414812
+ 24
+58.42768048061524
+ 13
+73035.01689945137
+ 23
+41996.216380797
+ 14
+-6.582271388091974
+ 24
+50.1874881421112
+ 13
+736461.621360815
+ 23
+1285411.102705096
+ 14
+4.285815150609035
+ 24
+61.30451000036674
+ 13
+135782.6707433862
+ 23
+885073.2266890334
+ 14
+-6.445879693018328
+ 24
+57.77714442165881
+ 13
+205699.0776440508
+ 23
+1126055.039531085
+ 14
+-5.483477811622424
+ 24
+59.97331370435874
+ 13
+556642.3480201969
+ 23
+25734.42630721722
+ 14
+0.1894608278526199
+ 24
+50.11104273356229
+ 13
+130184.5716689415
+ 23
+613957.5613318856
+ 14
+-6.257321832736709
+ 24
+55.34534386282005
+ 13
+358737.9298637404
+ 23
+805081.8254039844
+ 14
+-2.6833264008286
+ 24
+57.13476746485633
+ 13
+594372.8517844355
+ 23
+222150.929293326
+ 14
+0.8216053315465789
+ 24
+51.86408136172466
+ 13
+420878.7498757481
+ 23
+738831.5764170158
+ 14
+-1.66210368067514
+ 24
+56.5410186517866
+ 13
+775142.0380123855
+ 23
+1077911.086769703
+ 14
+4.61530531008361
+ 24
+59.41936066548881
+ 13
+734167.50814081
+ 23
+1160435.027815654
+ 14
+4.029433277460922
+ 24
+60.19087732624475
+ 13
+567549.3535943773
+ 23
+1000581.484228993
+ 14
+0.9032999141399239
+ 24
+58.8599754221816
+ 13
+597094.737611275
+ 23
+993384.9869556787
+ 14
+1.408254446232614
+ 24
+58.7829509652627
+ 13
+62985.04033416579
+ 23
+552860.1862472257
+ 14
+-7.240648646295555
+ 24
+54.75722430153284
+ 13
+509834.8008519137
+ 23
+1008096.765883531
+ 14
+-0.0928558879405479
+ 24
+58.94602617640058
+ 13
+42343.29322637242
+ 23
+508500.6000851508
+ 14
+-7.506067559142588
+ 24
+54.34617191584957
+ 13
+6124.289145086077
+ 23
+518650.5875357056
+ 14
+-8.073622652748301
+ 24
+54.41023002662624
+ 13
+9592.097725656593
+ 23
+550898.0998657346
+ 14
+-8.063237529445713
+ 24
+54.70109202873391
+ 13
+701838.5040637678
+ 23
+324491.6741438765
+ 14
+2.469811615473909
+ 24
+52.73370723287578
+ 13
+530475.3220488944
+ 23
+329913.1682629482
+ 14
+-0.0638674570890384
+ 24
+52.8509396704969
+ 13
+409751.4543208152
+ 23
+358477.665296157
+ 14
+-1.855734179571997
+ 24
+53.12340088956793
+ 13
+187862.5176145455
+ 23
+909467.0457521253
+ 14
+-5.593877171372305
+ 24
+58.02349764840609
+ 13
+738489.8459450105
+ 23
+1117544.883862195
+ 14
+4.036510357755993
+ 24
+59.80436824540575
+ 13
+234180.1768755633
+ 23
+1079989.389435006
+ 14
+-4.937444805149862
+ 24
+59.57269993000686
+ 13
+722440.204095842
+ 23
+1244047.570981899
+ 14
+3.955348169714468
+ 24
+60.94703872943919
+ 13
+197323.0195069852
+ 23
+1005632.217680233
+ 14
+-5.519219905388841
+ 24
+58.89000183933411
+ 13
+447982.3975192952
+ 23
+1148548.570763796
+ 14
+-1.135866852906178
+ 24
+60.2184615551023
+ 13
+769060.5310795408
+ 23
+435008.2521883765
+ 14
+3.588598037464092
+ 24
+53.68089644944113
+ 13
+296192.1534815312
+ 23
+246235.968200595
+ 14
+-3.51707936992907
+ 24
+52.10469133217307
+ 13
+369388.892307661
+ 23
+995737.0782998271
+ 14
+-2.532191099443251
+ 24
+58.84796693997047
+ 13
+544970.2106751878
+ 23
+241966.9328503919
+ 14
+0.1130737820294698
+ 24
+52.05713558460487
+ 13
+353391.7344259676
+ 23
+449344.2653690949
+ 14
+-2.711454578493685
+ 24
+53.93811616268489
+ 13
+775568.3662641641
+ 23
+93614.16251502872
+ 14
+3.30912310220092
+ 24
+50.62108337619075
+ 13
+16566.9861297668
+ 23
+353824.3663570435
+ 14
+-7.710023779459487
+ 24
+52.94433797681328
+ 13
+112635.2248073631
+ 23
+826175.0479978374
+ 14
+-6.764349471122196
+ 24
+57.23571928650929
+ 13
+222940.2932941737
+ 23
+781915.6411029831
+ 14
+-4.908488544568641
+ 24
+56.89466667357243
+ 13
+69197.55864894442
+ 23
+452923.6184656841
+ 14
+-7.033851232217165
+ 24
+53.86674721266755
+ 13
+111774.7162117325
+ 23
+527622.1864082348
+ 14
+-6.460087492027107
+ 24
+54.56147562003828
+ 13
+130690.6315097428
+ 23
+1229220.205755281
+ 14
+-6.961544269692399
+ 24
+60.85397698990973
+ 13
+695627.949380888
+ 23
+725887.5049167105
+ 14
+2.781638198405348
+ 24
+56.33292410845064
+ 13
+648484.969124423
+ 23
+337498.3724367073
+ 14
+1.69134794263365
+ 24
+52.877537777531
+ 13
+431979.2960553082
+ 23
+-34091.04981321537
+ 14
+-1.558844728920481
+ 24
+49.59277496859751
+ 13
+395485.9700232502
+ 23
+-52090.45452882419
+ 14
+-2.063574785345604
+ 24
+49.43170037888639
+ 13
+366774.5215231923
+ 23
+-62931.97466464411
+ 14
+-2.458621391317695
+ 24
+49.33329023457266
+ 13
+641977.9202477845
+ 23
+482096.4196885835
+ 14
+1.706513142404746
+ 24
+54.1775481315355
+ 13
+548536.4890097013
+ 23
+1236469.421731956
+ 14
+0.7434279872182773
+ 24
+60.98275736324554
+ 13
+547098.5065540117
+ 23
+892381.95556995
+ 14
+0.4800257622427254
+ 24
+57.89661166224413
+ 13
+719240.7203761648
+ 23
+359771.1373507579
+ 14
+2.761239024609558
+ 24
+53.03977959276987
+ 13
+646354.93982078
+ 23
+1000904.650446826
+ 14
+2.26631578905352
+ 24
+58.82500003192104
+ 13
+523734.5099926633
+ 23
+105444.8980359948
+ 14
+-0.2441864177693844
+ 24
+50.83531140342675
+ 13
+195897.0287593393
+ 23
+1164924.207376849
+ 14
+-5.697649784343276
+ 24
+60.31684710554856
+ 13
+165961.8841094585
+ 23
+456745.9919260525
+ 14
+-5.568531404475971
+ 24
+53.95372760802096
+ 13
+75762.56246793349
+ 23
+1208724.553695895
+ 14
+-7.933244198077993
+ 24
+60.62995052809085
+ 13
+596123.0895126966
+ 23
+772116.2824787623
+ 14
+1.210126017199107
+ 24
+56.79921075206049
+ 13
+343329.5276382555
+ 23
+26184.49700241021
+ 14
+-2.794271234386089
+ 24
+50.13300661432715
+ 13
+597241.9570840838
+ 23
+547905.4444462087
+ 14
+1.066054622514396
+ 24
+54.78726077178499
+ 13
+378326.8412598202
+ 23
+636550.7359916442
+ 14
+-2.34571256936521
+ 24
+55.62204998789084
+ 13
+501716.137550005
+ 23
+877380.8457644554
+ 14
+-0.2915303323079226
+ 24
+57.7745622330299
+ 13
+306105.7891043617
+ 23
+328821.0927600761
+ 14
+-3.395673436342887
+ 24
+52.84869054214126
+ 13
+146483.9114860874
+ 23
+636670.664126845
+ 14
+-6.021649999890014
+ 24
+55.55760406942687
+ 13
+646670.0584620681
+ 23
+201141.4374611625
+ 14
+1.564825972129905
+ 24
+51.65490661480498
+ 13
+181079.1596036388
+ 23
+-12091.90094413258
+ 14
+-5.040538296125067
+ 24
+49.75156360831729
+ 13
+685736.8446450351
+ 23
+881158.3841467076
+ 14
+2.798451286414494
+ 24
+57.72910013882489
+ 13
+763327.7810537567
+ 23
+178531.7467452982
+ 14
+3.221715685009416
+ 24
+51.38930598273625
+ 13
+77244.86333916387
+ 23
+607636.0306101713
+ 14
+-7.081707549233168
+ 24
+55.25688590519419
+ 13
+103263.7924471616
+ 23
+1034935.842866404
+ 14
+-7.184521809671108
+ 24
+59.09745445207172
+ 13
+711170.6822567306
+ 23
+976989.1495141072
+ 14
+3.351159348825965
+ 24
+58.56927870063695
+ 13
+666982.6523418355
+ 23
+1237621.933254571
+ 14
+2.926757595816582
+ 24
+60.93087603151377
+ 13
+296322.7650802151
+ 23
+987007.9357044023
+ 14
+-3.79384294620053
+ 24
+58.75818643854683
+ 13
+340295.8763760898
+ 23
+361237.2452068615
+ 14
+-2.894072316349135
+ 24
+53.14493330753722
+ 13
+298148.8095865543
+ 23
+381922.601817916
+ 14
+-3.530623702119539
+ 24
+53.32440851104615
+ 13
+348569.7263257203
+ 23
+862179.8866358219
+ 14
+-2.863266662452439
+ 24
+57.64657196597522
+ 13
+24925.48412322099
+ 23
+68125.71389970132
+ 14
+-7.279382234872657
+ 24
+50.39300483453934
+ 13
+329569.3058891566
+ 23
+624161.5114365895
+ 14
+-3.116650201918026
+ 24
+55.50612601088245
+ 13
+497382.6066530702
+ 23
+364022.8320309546
+ 14
+-0.5448307790362735
+ 24
+53.16445207331096
+ 13
+39301.42888426768
+ 23
+876185.2197495144
+ 14
+-8.046444544412235
+ 24
+57.63064116765221
+ 13
+603924.8719299799
+ 23
+631402.3243508949
+ 14
+1.229833765999132
+ 24
+55.53370998502609
+ 13
+426422.0496029092
+ 23
+620405.4456689387
+ 14
+-1.583564490384761
+ 24
+55.47676125302763
+ 13
+460051.0252940982
+ 23
+666386.323742484
+ 14
+-1.041558283947108
+ 24
+55.88688137036635
+ 13
+114958.4167035355
+ 23
+185167.1836056647
+ 14
+-6.107995004225738
+ 24
+51.49340947836055
+ 13
+233071.4492921236
+ 23
+219241.8581111794
+ 14
+-4.424831787372987
+ 24
+51.84675942525031
+ 13
+-447.7317928955244
+ 23
+1248544.554211802
+ 14
+-9.39691675869118
+ 24
+60.91575881050168
+ 13
+72628.48128599058
+ 23
+80710.60984120018
+ 14
+-6.621596344599215
+ 24
+50.53431090472759
+ 13
+54770.88672108876
+ 23
+388302.0293850655
+ 14
+-7.180956903578406
+ 24
+53.27892775878351
+ 13
+567343.0391319051
+ 23
+505008.5736672652
+ 14
+0.577190957079843
+ 24
+54.41300769197144
+ 13
+339069.7861412664
+ 23
+214697.3421119006
+ 14
+-2.885539302217749
+ 24
+51.82755905718309
+ 13
+386247.6324960447
+ 23
+-25981.7972574402
+ 14
+-2.191900320241735
+ 24
+49.66639278450232
+ 13
+515920.3696914694
+ 23
+825950.5968381288
+ 14
+-0.0773448902824539
+ 24
+57.30940980919937
+ 13
+189480.8942797989
+ 23
+-48962.89264710463
+ 14
+-4.904314483135874
+ 24
+49.42336041342358
+ 13
+597498.4690992876
+ 23
+10536.07896084533
+ 14
+0.7524202265739796
+ 24
+49.96233961157194
+ 13
+306050.9141946853
+ 23
+82366.08144788617
+ 14
+-3.329803187822538
+ 24
+50.63338134315628
+ 13
+131804.2740238081
+ 23
+680321.6462536369
+ 14
+-6.296578692432811
+ 24
+55.94086088379406
+ 13
+142559.1598193327
+ 23
+1274779.504980754
+ 14
+-6.805372826435498
+ 24
+61.26946215521494
+ 13
+728566.2046361619
+ 23
+-6548.835886056171
+ 14
+2.560474238248787
+ 24
+49.75153365222465
+ 13
+651223.0024234887
+ 23
+1161858.496421189
+ 14
+2.540553255702292
+ 24
+60.26314826282923
+ 13
+360956.2755215774
+ 23
+331216.5613645198
+ 14
+-2.581564485991048
+ 24
+52.87700533760524
+ 13
+191907.6953665194
+ 23
+336263.0509301198
+ 14
+-5.094197702538586
+ 24
+52.88347708847267
+ 13
+653834.2467803961
+ 23
+-704.4900468542145
+ 14
+1.529118135321031
+ 24
+49.840163109521
+ 13
+308171.3195656166
+ 23
+531374.190660751
+ 14
+-3.425358844422859
+ 24
+54.66904962558422
+ 13
+485144.911538237
+ 23
+1058615.460216957
+ 14
+-0.5020561864075546
+ 24
+59.40514780953959
+ 13
+606122.5079930906
+ 23
+172595.8759277825
+ 14
+0.9628489757661792
+ 24
+51.41490170616187
+ 13
+381265.0327541231
+ 23
+1061238.559247646
+ 14
+-2.332048653819115
+ 24
+59.43686083186586
+ 13
+70607.75338205043
+ 23
+359524.2173659775
+ 14
+-6.914756257475172
+ 24
+53.03127511863252
+ 13
+749294.441415724
+ 23
+1059626.596085825
+ 14
+4.132920528861365
+ 24
+59.27835044372937
+ 13
+498137.5835218152
+ 23
+82071.50318550443
+ 14
+-0.6137809383681523
+ 24
+50.63008323478954
+ 13
+201557.4130296033
+ 23
+958639.1485105254
+ 14
+-5.404505800868107
+ 24
+58.47069665418776
+ 13
+606941.340421039
+ 23
+737293.422821983
+ 14
+1.359048697023441
+ 24
+56.48223761824594
+ 13
+307586.3257473764
+ 23
+481005.2482961029
+ 14
+-3.418691700160469
+ 24
+54.21642055900868
+ 13
+9604.729189442281
+ 23
+-56204.84185986574
+ 14
+-7.368837267591229
+ 24
+49.26982512335996
+ 13
+56597.6977414909
+ 23
+776273.7131775072
+ 14
+-7.620484203741104
+ 24
+56.75107274984807
+ 13
+27006.53340805409
+ 23
+778001.3838838732
+ 14
+-8.104186910737634
+ 24
+56.74380233022088
+ 13
+741410.6023608636
+ 23
+308971.3955041971
+ 14
+3.037638403118041
+ 24
+52.57122930997537
+ 13
+519651.5478807171
+ 23
+610164.6119555438
+ 14
+-0.1135875560965642
+ 24
+55.37090189461719
+ 13
+703532.2787134823
+ 23
+789624.6307755785
+ 14
+2.983764708722079
+ 24
+56.89839911693042
+ 13
+159344.1119097831
+ 23
+969217.0548226428
+ 14
+-6.13753730199613
+ 24
+58.54422361207327
+ 13
+145492.0390532345
+ 23
+181313.1470689924
+ 14
+-5.666344591109329
+ 24
+51.47339658150912
+ 13
+437319.1533829457
+ 23
+1038111.847428389
+ 14
+-1.34786708972385
+ 24
+59.22797800336589
+ 13
+444768.8776963875
+ 23
+427314.6296291979
+ 14
+-1.32273789358149
+ 24
+53.74031719433085
+ 13
+468716.7727937151
+ 23
+1249380.359736716
+ 14
+-0.726525992181693
+ 24
+61.12055470487178
+ 13
+455231.1567309485
+ 23
+1281421.782289096
+ 14
+-0.9673677886540177
+ 24
+61.41027756034802
+ 13
+416234.507893744
+ 23
+1307473.783335719
+ 14
+-1.69551756747498
+ 24
+61.64772075573575
+ 13
+483656.2300146299
+ 23
+1307116.759837761
+ 14
+-0.4234916364564035
+ 24
+61.63577597560977
+ 13
+423891.5079886344
+ 23
+1276722.773298057
+ 14
+-1.554962259110184
+ 24
+61.37128099021111
+ 13
+511415.3786039667
+ 23
+1312424.744021871
+ 14
+0.1031412139269858
+ 24
+61.67635996730981
+ 13
+526798.4340448863
+ 23
+186847.4600206532
+ 14
+-0.1719675940297103
+ 24
+51.56625694449596
+ 13
+360714.2557972348
+ 23
+405489.5815656647
+ 14
+-2.594332256834297
+ 24
+53.54458167251113
+ 13
+591377.9987241319
+ 23
+463771.5401769265
+ 14
+0.9208086600313921
+ 24
+54.03442557549376
+ 13
+54407.34917163125
+ 23
+155299.4759625464
+ 14
+-6.948178889741591
+ 24
+51.19211735510276
+ 13
+568953.7566008127
+ 23
+590816.0744802238
+ 14
+0.6519455823350388
+ 24
+55.18276348837933
+ 13
+482124.8423651949
+ 23
+1150244.96072294
+ 14
+-0.5191915735202766
+ 24
+60.22824937522537
+ 13
+141845.7893218067
+ 23
+503824.8611822503
+ 14
+-5.97547711622237
+ 24
+54.364366342799
+ 13
+153846.0590949954
+ 23
+152653.9819650645
+ 14
+-5.52647427341644
+ 24
+51.21988566285978
+ 13
+132974.2079762648
+ 23
+133759.2001638031
+ 14
+-5.810692263963743
+ 24
+51.04098014984955
+ 13
+215838.1907871012
+ 23
+1037424.884715973
+ 14
+-5.22511775352324
+ 24
+59.1834070765385
+ 13
+466167.6304988628
+ 23
+957910.0281135417
+ 14
+-0.8662888018230948
+ 24
+58.50434830109257
+ 13
+110080.4410659898
+ 23
+14159.76320378851
+ 14
+-6.043627737080741
+ 24
+49.95705462349519
+ 13
+260277.4645551728
+ 23
+22493.8287550668
+ 14
+-3.954475813528613
+ 24
+50.08606426663209
+ 13
+185336.9071023937
+ 23
+118836.9656350547
+ 14
+-5.056160636080296
+ 24
+50.92893971864323
+ 13
+694874.8514895566
+ 23
+447983.6983204349
+ 14
+2.48154841816414
+ 24
+53.8442708017718
+ 13
+75195.27608140134
+ 23
+959270.3208414274
+ 14
+-7.562712384212322
+ 24
+58.40072407805052
+ 13
+223064.4666066274
+ 23
+89420.26490091119
+ 14
+-4.505699903149977
+ 24
+50.67747091366873
+ 13
+419654.0473392945
+ 23
+1063395.017565226
+ 14
+-1.655081403576117
+ 24
+59.4561964547531
+ 13
+202774.3659235691
+ 23
+730280.9140294937
+ 14
+-5.199471849419674
+ 24
+56.42339313284977
+ 13
+549380.8058209467
+ 23
+973414.3154282968
+ 14
+0.5706216670865649
+ 24
+58.62292780963646
+ 13
+680059.7906134007
+ 23
+933858.123588042
+ 14
+2.765779600556638
+ 24
+58.20439532670112
+ 96
+        0
+  0
+SORTENTSTABLE
+  5
+225
+102
+{ACAD_REACTORS
+330
+15D
+102
+}
+330
+15D
+100
+AcDbSortentsTable
+330
+1F
+  0
+ACDBDETAILVIEWSTYLE
+  5
+1AC
+102
+{ACAD_REACTORS
+330
+1AB
+102
+}
+330
+1AB
+100
+AcDbModelDocViewStyle
+ 70
+     0
+  3
+Imperial24
+290
+     0
+300
+Imperial24
+ 90
+        0
+100
+AcDbDetailViewStyle
+ 70
+     0
+ 71
+     0
+ 90
+        3
+ 71
+     1
+340
+11
+ 62
+   256
+ 40
+0.24
+340
+0
+ 62
+   256
+ 40
+0.24
+300
+
+ 40
+0.36
+280
+     3
+ 71
+     2
+340
+16
+ 90
+       25
+ 62
+   256
+ 71
+     3
+340
+11
+ 62
+   256
+ 40
+0.24
+ 90
+        1
+ 40
+0.75
+ 90
+        1
+300
+%<\AcVar ViewType \f "%tc1">% %<\AcVar ViewDetailId>%\PSCALE %<\AcVar ViewScale \f "%sn">%
+ 71
+     4
+340
+16
+ 90
+       25
+ 62
+   256
+340
+16
+ 90
+       25
+ 62
+   256
+280
+     0
+  0
+LAYOUT
+  5
+59
+102
+{ACAD_REACTORS
+330
+1A
+102
+}
+330
+1A
+100
+AcDbPlotSettings
+  1
+
+  2
+None
+  4
+
+  6
+
+ 40
+0.0
+ 41
+0.0
+ 42
+0.0
+ 43
+0.0
+ 44
+0.0
+ 45
+0.0
+ 46
+0.0
+ 47
+0.0
+ 48
+0.0
+ 49
+0.0
+140
+0.0
+141
+0.0
+142
+1.0
+143
+1.0
+ 70
+   688
+ 72
+     0
+ 73
+     0
+ 74
+     5
+  7
+
+ 75
+    16
+147
+1.0
+ 76
+     0
+ 77
+     2
+ 78
+   300
+148
+0.0
+149
+0.0
+100
+AcDbLayout
+  1
+Layout1
+ 70
+     1
+ 71
+     1
+ 10
+0.0
+ 20
+0.0
+ 11
+12.0
+ 21
+9.0
+ 12
+0.0
+ 22
+0.0
+ 32
+0.0
+ 14
+0.0
+ 24
+0.0
+ 34
+0.0
+ 15
+0.0
+ 25
+0.0
+ 35
+0.0
+146
+0.0
+ 13
+0.0
+ 23
+0.0
+ 33
+0.0
+ 16
+1.0
+ 26
+0.0
+ 36
+0.0
+ 17
+0.0
+ 27
+1.0
+ 37
+0.0
+ 76
+     0
+330
+58
+  0
+LAYOUT
+  5
+5E
+102
+{ACAD_REACTORS
+330
+1A
+102
+}
+330
+1A
+100
+AcDbPlotSettings
+  1
+
+  2
+None
+  4
+
+  6
+
+ 40
+0.0
+ 41
+0.0
+ 42
+0.0
+ 43
+0.0
+ 44
+0.0
+ 45
+0.0
+ 46
+0.0
+ 47
+0.0
+ 48
+0.0
+ 49
+0.0
+140
+0.0
+141
+0.0
+142
+1.0
+143
+1.0
+ 70
+   688
+ 72
+     0
+ 73
+     0
+ 74
+     5
+  7
+
+ 75
+    16
+147
+1.0
+ 76
+     0
+ 77
+     2
+ 78
+   300
+148
+0.0
+149
+0.0
+100
+AcDbLayout
+  1
+Layout2
+ 70
+     1
+ 71
+     2
+ 10
+0.0
+ 20
+0.0
+ 11
+12.0
+ 21
+9.0
+ 12
+0.0
+ 22
+0.0
+ 32
+0.0
+ 14
+0.0
+ 24
+0.0
+ 34
+0.0
+ 15
+0.0
+ 25
+0.0
+ 35
+0.0
+146
+0.0
+ 13
+0.0
+ 23
+0.0
+ 33
+0.0
+ 16
+1.0
+ 26
+0.0
+ 36
+0.0
+ 17
+0.0
+ 27
+1.0
+ 37
+0.0
+ 76
+     0
+330
+5D
+  0
+LAYOUT
+  5
+22
+102
+{ACAD_XDICTIONARY
+360
+194
+102
+}
+102
+{ACAD_REACTORS
+330
+1A
+102
+}
+330
+1A
+100
+AcDbPlotSettings
+  1
+
+  2
+none_device
+  4
+ANSI_A_(8.50_x_11.00_Inches)
+  6
+
+ 40
+6.349999904632567
+ 41
+19.04999923706055
+ 42
+6.350006103515625
+ 43
+19.04998779296875
+ 44
+215.8999938964844
+ 45
+279.3999938964844
+ 46
+0.0
+ 47
+0.0
+ 48
+0.0
+ 49
+0.0
+140
+0.0
+141
+0.0
+142
+1.0
+143
+2.584895464708373
+ 70
+ 11952
+ 72
+     0
+ 73
+     1
+ 74
+     0
+  7
+
+ 75
+     0
+147
+0.3868628397755418
+ 76
+     0
+ 77
+     2
+ 78
+   300
+148
+0.0
+149
+0.0
+100
+AcDbLayout
+  1
+Model
+ 70
+     1
+ 71
+     0
+ 10
+0.0
+ 20
+0.0
+ 11
+12.0
+ 21
+9.0
+ 12
+0.0
+ 22
+0.0
+ 32
+0.0
+ 14
+0.0
+ 24
+0.0
+ 34
+0.0
+ 15
+0.0
+ 25
+0.0
+ 35
+0.0
+146
+0.0
+ 13
+0.0
+ 23
+0.0
+ 33
+0.0
+ 16
+1.0
+ 26
+0.0
+ 36
+0.0
+ 17
+0.0
+ 27
+1.0
+ 37
+0.0
+ 76
+     0
+330
+1F
+331
+94
+  0
+MATERIAL
+  5
+97
+102
+{ACAD_XDICTIONARY
+360
+188
+102
+}
+102
+{ACAD_REACTORS
+330
+72
+102
+}
+330
+72
+100
+AcDbMaterial
+  1
+ByBlock
+ 94
+       63
+  0
+MATERIAL
+  5
+96
+102
+{ACAD_XDICTIONARY
+360
+186
+102
+}
+102
+{ACAD_REACTORS
+330
+72
+102
+}
+330
+72
+100
+AcDbMaterial
+  1
+ByLayer
+ 94
+       63
+  0
+MATERIAL
+  5
+98
+102
+{ACAD_XDICTIONARY
+360
+110
+102
+}
+102
+{ACAD_REACTORS
+330
+72
+102
+}
+330
+72
+100
+AcDbMaterial
+  1
+Global
+ 43
+0.0208000000566244
+ 43
+0.0
+ 43
+0.0
+ 43
+0.0
+ 43
+0.0
+ 43
+0.0208000000566244
+ 43
+0.0
+ 43
+0.0
+ 43
+0.0
+ 43
+0.0
+ 43
+1.0
+ 43
+0.0
+ 43
+0.0
+ 43
+0.0
+ 43
+0.0
+ 43
+1.0
+ 49
+0.0208000000566244
+ 49
+0.0
+ 49
+0.0
+ 49
+0.0
+ 49
+0.0
+ 49
+0.0208000000566244
+ 49
+0.0
+ 49
+0.0
+ 49
+0.0
+ 49
+0.0
+ 49
+1.0
+ 49
+0.0
+ 49
+0.0
+ 49
+0.0
+ 49
+0.0
+ 49
+1.0
+142
+0.0208000000566244
+142
+0.0
+142
+0.0
+142
+0.0
+142
+0.0
+142
+0.0208000000566244
+142
+0.0
+142
+0.0
+142
+0.0
+142
+0.0
+142
+1.0
+142
+0.0
+142
+0.0
+142
+0.0
+142
+0.0
+142
+1.0
+144
+0.0208000000566244
+144
+0.0
+144
+0.0
+144
+0.0
+144
+0.0
+144
+0.0208000000566244
+144
+0.0
+144
+0.0
+144
+0.0
+144
+0.0
+144
+1.0
+144
+0.0
+144
+0.0
+144
+0.0
+144
+0.0
+144
+1.0
+ 94
+       63
+1001
+ACAD
+1070
+    -1
+1070
+     3
+1070
+     0
+1000
+
+1071
+        0
+1070
+     0
+  0
+MLEADERSTYLE
+  5
+E5
+102
+{ACAD_REACTORS
+330
+D7
+102
+}
+330
+D7
+100
+AcDbMLeaderStyle
+179
+     2
+170
+     2
+171
+     1
+172
+     0
+ 90
+        2
+ 40
+0.0
+ 41
+0.0
+173
+     1
+ 91
+-1056964608
+340
+14
+ 92
+       -2
+290
+     1
+ 42
+0.09
+291
+     1
+ 43
+0.36
+  3
+Standard
+ 44
+0.18
+300
+
+342
+11
+174
+     1
+178
+     1
+175
+     1
+176
+     0
+ 93
+-1056964608
+ 45
+0.18
+292
+     0
+297
+     0
+ 46
+0.18
+ 94
+-1056964608
+ 47
+1.0
+ 49
+1.0
+140
+1.0
+293
+     1
+141
+0.0
+294
+     1
+177
+     0
+142
+1.0
+295
+     0
+296
+     1
+143
+0.125
+271
+     0
+272
+     9
+273
+     9
+298
+     0
+  0
+MLEADERSTYLE
+  5
+D8
+102
+{ACAD_REACTORS
+330
+D7
+102
+}
+330
+D7
+100
+AcDbMLeaderStyle
+179
+     2
+170
+     2
+171
+     1
+172
+     0
+ 90
+        2
+ 40
+0.0
+ 41
+0.0
+173
+     1
+ 91
+-1056964608
+340
+14
+ 92
+       -2
+290
+     1
+ 42
+0.09
+291
+     1
+ 43
+0.36
+  3
+Standard
+ 44
+0.18
+300
+
+342
+11
+174
+     1
+178
+     1
+175
+     1
+176
+     0
+ 93
+-1056964608
+ 45
+0.18
+292
+     0
+297
+     0
+ 46
+0.18
+ 94
+-1056964608
+ 47
+1.0
+ 49
+1.0
+140
+1.0
+293
+     1
+141
+0.0
+294
+     1
+177
+     0
+142
+1.0
+295
+     0
+296
+     0
+143
+0.125
+271
+     0
+272
+     9
+273
+     9
+298
+     0
+  0
+MLINESTYLE
+  5
+18
+102
+{ACAD_REACTORS
+330
+17
+102
+}
+330
+17
+100
+AcDbMlineStyle
+  2
+STANDARD
+ 70
+     0
+  3
+
+ 62
+   256
+ 51
+90.0
+ 52
+90.0
+ 71
+     2
+ 49
+0.5
+ 62
+   256
+  6
+BYLAYER
+ 49
+-0.5
+ 62
+   256
+  6
+BYLAYER
+  0
+ACDBPLACEHOLDER
+  5
+F
+102
+{ACAD_REACTORS
+330
+E
+102
+}
+330
+E
+  0
+SCALE
+  5
+B7
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:1
+140
+1.0
+141
+1.0
+290
+     1
+  0
+SCALE
+  5
+124
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:2
+140
+1.0
+141
+2.0
+290
+     0
+  0
+SCALE
+  5
+125
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:4
+140
+1.0
+141
+4.0
+290
+     0
+  0
+SCALE
+  5
+126
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:5
+140
+1.0
+141
+5.0
+290
+     0
+  0
+SCALE
+  5
+127
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:8
+140
+1.0
+141
+8.0
+290
+     0
+  0
+SCALE
+  5
+128
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:10
+140
+1.0
+141
+10.0
+290
+     0
+  0
+SCALE
+  5
+129
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:16
+140
+1.0
+141
+16.0
+290
+     0
+  0
+SCALE
+  5
+12A
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:20
+140
+1.0
+141
+20.0
+290
+     0
+  0
+SCALE
+  5
+12B
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:30
+140
+1.0
+141
+30.0
+290
+     0
+  0
+SCALE
+  5
+12C
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:40
+140
+1.0
+141
+40.0
+290
+     0
+  0
+SCALE
+  5
+12D
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:50
+140
+1.0
+141
+50.0
+290
+     0
+  0
+SCALE
+  5
+12E
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1:100
+140
+1.0
+141
+100.0
+290
+     0
+  0
+SCALE
+  5
+12F
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+2:1
+140
+2.0
+141
+1.0
+290
+     0
+  0
+SCALE
+  5
+130
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+4:1
+140
+4.0
+141
+1.0
+290
+     0
+  0
+SCALE
+  5
+131
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+8:1
+140
+8.0
+141
+1.0
+290
+     0
+  0
+SCALE
+  5
+132
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+10:1
+140
+10.0
+141
+1.0
+290
+     0
+  0
+SCALE
+  5
+133
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+100:1
+140
+100.0
+141
+1.0
+290
+     0
+  0
+SCALE
+  5
+134
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1/128" = 1'-0"
+140
+0.0078125
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+135
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1/64" = 1'-0"
+140
+0.015625
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+136
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1/32" = 1'-0"
+140
+0.03125
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+137
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1/16" = 1'-0"
+140
+0.0625
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+138
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+3/32" = 1'-0"
+140
+0.09375
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+139
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1/8" = 1'-0"
+140
+0.125
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+13A
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+3/16" = 1'-0"
+140
+0.1875
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+13B
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1/4" = 1'-0"
+140
+0.25
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+13C
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+3/8" = 1'-0"
+140
+0.375
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+13D
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1/2" = 1'-0"
+140
+0.5
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+13E
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+3/4" = 1'-0"
+140
+0.75
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+13F
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1" = 1'-0"
+140
+1.0
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+140
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1-1/2" = 1'-0"
+140
+1.5
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+141
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+3" = 1'-0"
+140
+3.0
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+142
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+6" = 1'-0"
+140
+6.0
+141
+12.0
+290
+     0
+  0
+SCALE
+  5
+143
+102
+{ACAD_REACTORS
+330
+B6
+102
+}
+330
+B6
+100
+AcDbScale
+ 70
+     0
+300
+1'-0" = 1'-0"
+140
+12.0
+141
+12.0
+290
+     0
+  0
+ACDBSECTIONVIEWSTYLE
+  5
+1AA
+102
+{ACAD_REACTORS
+330
+1A8
+102
+}
+330
+1A8
+100
+AcDbModelDocViewStyle
+ 70
+     0
+  3
+Imperial24
+290
+     0
+300
+Imperial24
+ 90
+        0
+100
+AcDbSectionViewStyle
+ 70
+     0
+ 71
+     0
+ 90
+       78
+ 71
+     1
+340
+11
+ 62
+   256
+ 40
+0.24
+340
+0
+340
+0
+ 62
+   256
+ 40
+0.24
+300
+I, O, Q, S, X, Z
+ 40
+0.48
+ 90
+        3
+ 40
+0.18
+ 90
+        1
+ 71
+     2
+340
+16
+ 90
+       25
+ 62
+   256
+340
+16
+ 90
+       50
+ 62
+   256
+ 40
+0.24
+ 40
+0.0
+ 40
+0.24
+ 71
+     3
+340
+11
+ 62
+   256
+ 40
+0.24
+ 90
+        1
+ 40
+0.75
+ 90
+        1
+300
+%<\AcVar ViewType \f "%tc1">% %<\AcVar ViewSectionStartId>%-%<\AcVar ViewSectionEndId>%\PSCALE %<\AcVar ViewScale \f "%sn">%
+ 71
+     4
+ 62
+   256
+ 62
+   257
+300
+ANSI31
+ 40
+1.0
+ 90
+        0
+290
+     0
+290
+     0
+ 90
+        6
+ 40
+0.0
+ 40
+1.570796326794896
+ 40
+0.2617993877991494
+ 40
+1.308996938995747
+ 40
+-0.2617993877991494
+ 40
+1.832595714594045
+  0
+TABLESTYLE
+  5
+87
+102
+{ACAD_XDICTIONARY
+360
+104
+102
+}
+102
+{ACAD_REACTORS
+330
+86
+102
+}
+330
+86
+100
+AcDbTableStyle
+280
+     0
+  3
+Standard
+ 70
+     0
+ 71
+     0
+ 40
+0.06
+ 41
+0.06
+280
+     0
+281
+     0
+  7
+Standard
+140
+0.18
+170
+     2
+ 62
+     0
+ 63
+     7
+283
+     0
+ 90
+      512
+ 91
+        0
+  1
+
+274
+    -2
+284
+     1
+ 64
+     0
+275
+    -2
+285
+     1
+ 65
+     0
+276
+    -2
+286
+     1
+ 66
+     0
+277
+    -2
+287
+     1
+ 67
+     0
+278
+    -2
+288
+     1
+ 68
+     0
+279
+    -2
+289
+     1
+ 69
+     0
+  7
+Standard
+140
+0.25
+170
+     5
+ 62
+     0
+ 63
+     7
+283
+     0
+ 90
+      512
+ 91
+        0
+  1
+
+274
+    -2
+284
+     1
+ 64
+     0
+275
+    -2
+285
+     1
+ 65
+     0
+276
+    -2
+286
+     1
+ 66
+     0
+277
+    -2
+287
+     1
+ 67
+     0
+278
+    -2
+288
+     1
+ 68
+     0
+279
+    -2
+289
+     1
+ 69
+     0
+  7
+Standard
+140
+0.18
+170
+     5
+ 62
+     0
+ 63
+     7
+283
+     0
+ 90
+      512
+ 91
+        0
+  1
+
+274
+    -2
+284
+     1
+ 64
+     0
+275
+    -2
+285
+     1
+ 65
+     0
+276
+    -2
+286
+     1
+ 66
+     0
+277
+    -2
+287
+     1
+ 67
+     0
+278
+    -2
+288
+     1
+ 68
+     0
+279
+    -2
+289
+     1
+ 69
+     0
+  0
+VISUALSTYLE
+  5
+9F
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+2dWireframe
+ 70
+     4
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        0
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+   257
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+9E
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Basic
+ 70
+     7
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A5
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Brighten
+ 70
+    12
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+50.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A9
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+ColorChange
+ 70
+    16
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     8
+420
+  8421504
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     8
+420
+  8421504
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A2
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Conceptual
+ 70
+     9
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        3
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+40.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A4
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Dim
+ 70
+    11
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+-50.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+175
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+EdgeColorOff
+ 70
+    22
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     0
+ 90
+        2
+176
+     0
+ 90
+        0
+176
+     0
+ 90
+        0
+176
+     0
+ 40
+0.6
+176
+     0
+ 40
+30.0
+176
+     0
+ 62
+     7
+420
+ 16777215
+176
+     0
+ 90
+        1
+176
+     0
+ 90
+        4
+176
+     0
+ 62
+     7
+176
+     0
+ 62
+   257
+176
+     0
+ 90
+        1
+176
+     0
+ 90
+        1
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        8
+176
+     2
+ 62
+     7
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        1
+176
+     0
+ 90
+        6
+176
+     0
+ 90
+        2
+176
+     0
+ 62
+     7
+176
+     0
+ 90
+        5
+176
+     0
+ 90
+        0
+176
+     0
+ 90
+        0
+176
+     0
+290
+     0
+176
+     0
+ 90
+        1
+176
+     0
+ 40
+0.0
+176
+     0
+ 90
+        0
+176
+     0
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A8
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Facepattern
+ 70
+    15
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+9A
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Flat
+ 70
+     0
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        2
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       13
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+9B
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+FlatWithEdges
+ 70
+     1
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        2
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+   257
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       13
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+9C
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Gouraud
+ 70
+     2
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        2
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       13
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+9D
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+GouraudWithEdges
+ 70
+     3
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        2
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+   257
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       13
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A1
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Hidden
+ 70
+     6
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        1
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+40.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+   257
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+173
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+JitterOff
+ 70
+    20
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     0
+ 90
+        2
+176
+     0
+ 90
+        0
+176
+     0
+ 90
+        0
+176
+     0
+ 40
+0.6
+176
+     0
+ 40
+30.0
+176
+     0
+ 62
+     7
+420
+ 16777215
+176
+     0
+ 90
+        1
+176
+     0
+ 90
+        4
+176
+     0
+ 62
+     7
+176
+     0
+ 62
+   257
+176
+     0
+ 90
+        1
+176
+     0
+ 90
+        1
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+       10
+176
+     2
+ 62
+     7
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        1
+176
+     0
+ 90
+        6
+176
+     0
+ 90
+        2
+176
+     0
+ 62
+     7
+176
+     0
+ 90
+        5
+176
+     0
+ 90
+        0
+176
+     0
+ 90
+        0
+176
+     0
+290
+     0
+176
+     0
+ 90
+        1
+176
+     0
+ 40
+0.0
+176
+     0
+ 90
+        0
+176
+     0
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A7
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Linepattern
+ 70
+    14
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        7
+176
+     1
+ 90
+        7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+174
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+OverhangOff
+ 70
+    21
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     0
+ 90
+        2
+176
+     0
+ 90
+        0
+176
+     0
+ 90
+        0
+176
+     0
+ 40
+0.6
+176
+     0
+ 40
+30.0
+176
+     0
+ 62
+     7
+420
+ 16777215
+176
+     0
+ 90
+        1
+176
+     0
+ 90
+        4
+176
+     0
+ 62
+     7
+176
+     0
+ 62
+   257
+176
+     0
+ 90
+        1
+176
+     0
+ 90
+        1
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        9
+176
+     2
+ 62
+     7
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        1
+176
+     0
+ 90
+        6
+176
+     0
+ 90
+        2
+176
+     0
+ 62
+     7
+176
+     0
+ 90
+        5
+176
+     0
+ 90
+        0
+176
+     0
+ 90
+        0
+176
+     0
+290
+     0
+176
+     0
+ 90
+        1
+176
+     0
+ 40
+0.0
+176
+     0
+ 90
+        0
+176
+     0
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A3
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Realistic
+ 70
+     8
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        2
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+   257
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       13
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+182
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Shaded
+ 70
+    27
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        2
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+   257
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     8
+420
+  7895160
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        5
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+181
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Shaded with edges
+ 70
+    26
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        2
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+   257
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        5
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+17E
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Shades of Gray
+ 70
+    23
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+40.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+17F
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Sketchy
+ 70
+    24
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        1
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+40.0
+176
+     1
+ 90
+       11
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A6
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Thicken
+ 70
+    13
+177
+     3
+291
+     1
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+       12
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        5
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+A0
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+Wireframe
+ 70
+     5
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        0
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+ 40
+0.6
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        4
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+   257
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+VISUALSTYLE
+  5
+180
+102
+{ACAD_REACTORS
+330
+99
+102
+}
+330
+99
+100
+AcDbVisualStyle
+  2
+X-Ray
+ 70
+    25
+177
+     3
+291
+     0
+ 70
+    58
+ 90
+        2
+176
+     1
+ 90
+        2
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+0.5
+176
+     1
+ 40
+30.0
+176
+     1
+ 62
+     7
+420
+ 16777215
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+     7
+176
+     1
+ 62
+   257
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        1
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        8
+176
+     1
+ 62
+     7
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        1
+176
+     1
+ 90
+        6
+176
+     1
+ 90
+        2
+176
+     1
+ 62
+     7
+176
+     1
+ 90
+        3
+176
+     1
+ 90
+        0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       13
+176
+     1
+ 40
+0.0
+176
+     1
+ 90
+        0
+176
+     1
+290
+     0
+176
+     1
+290
+     1
+176
+     1
+290
+     1
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 40
+0.0
+176
+     1
+ 40
+1.0
+176
+     1
+ 90
+        0
+176
+     1
+ 62
+    18
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+        3
+176
+     1
+ 62
+     5
+420
+      255
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+ 90
+       50
+176
+     1
+290
+     0
+176
+     1
+ 90
+       50
+176
+     1
+ 62
+   256
+176
+     0
+ 40
+1.0
+176
+     0
+ 90
+        2
+176
+     1
+  1
+strokes_ogs.tif
+176
+     1
+290
+     0
+176
+     1
+ 40
+1.0
+176
+     1
+ 40
+1.0
+176
+     1
+  0
+DICTIONARYVAR
+  5
+F0
+102
+{ACAD_REACTORS
+330
+66
+102
+}
+330
+66
+100
+DictionaryVariables
+280
+     0
+  1
+1:1
+  0
+DICTIONARYVAR
+  5
+EF
+102
+{ACAD_REACTORS
+330
+66
+102
+}
+330
+66
+100
+DictionaryVariables
+280
+     0
+  1
+STANDARD
+  0
+DICTIONARYVAR
+  5
+89
+102
+{ACAD_REACTORS
+330
+66
+102
+}
+330
+66
+100
+DictionaryVariables
+280
+     0
+  1
+STANDARD
+  0
+DICTIONARYVAR
+  5
+1B7
+102
+{ACAD_REACTORS
+330
+66
+102
+}
+330
+66
+100
+DictionaryVariables
+280
+     0
+  1
+Imperial24
+  0
+DICTIONARYVAR
+  5
+1B8
+102
+{ACAD_REACTORS
+330
+66
+102
+}
+330
+66
+100
+DictionaryVariables
+280
+     0
+  1
+Imperial24
+  0
+DICTIONARYVAR
+  5
+67
+102
+{ACAD_REACTORS
+330
+66
+102
+}
+330
+66
+100
+DictionaryVariables
+280
+     0
+  1
+2
+  0
+DICTIONARYVAR
+  5
+6B
+102
+{ACAD_REACTORS
+330
+66
+102
+}
+330
+66
+100
+DictionaryVariables
+280
+     0
+  1
+1
+  0
+DICTIONARYVAR
+  5
+14D
+102
+{ACAD_REACTORS
+330
+66
+102
+}
+330
+66
+100
+DictionaryVariables
+280
+     0
+  1
+0
+  0
+DICTIONARYVAR
+  5
+14E
+102
+{ACAD_REACTORS
+330
+66
+102
+}
+330
+66
+100
+DictionaryVariables
+280
+     0
+  1
+0
+  0
+DICTIONARYVAR
+  5
+23E
+102
+{ACAD_REACTORS
+330
+220
+102
+}
+330
+220
+100
+DictionaryVariables
+280
+     0
+  1
+1
+  0
+DICTIONARY
+  5
+194
+330
+22
+100
+AcDbDictionary
+280
+     1
+281
+     1
+  0
+DICTIONARY
+  5
+188
+330
+97
+100
+AcDbDictionary
+280
+     1
+281
+     1
+  3
+FBXASSET
+360
+189
+  0
+DICTIONARY
+  5
+186
+330
+96
+100
+AcDbDictionary
+280
+     1
+281
+     1
+  3
+FBXASSET
+360
+187
+  0
+DICTIONARY
+  5
+110
+330
+98
+100
+AcDbDictionary
+280
+     1
+281
+     1
+  3
+BUMPTILE
+360
+112
+  3
+DIFFUSETILE
+360
+111
+  3
+FBXASSET
+360
+18A
+  3
+OPACITYTILE
+360
+113
+  3
+REFLECTIONTILE
+360
+114
+  0
+DICTIONARY
+  5
+104
+330
+87
+100
+AcDbDictionary
+280
+     1
+281
+     1
+  3
+ACAD_ROUNDTRIP_2008_TABLESTYLE_CELLSTYLEMAP
+360
+23F
+  0
+XRECORD
+  5
+189
+102
+{ACAD_REACTORS
+330
+188
+102
+}
+330
+188
+100
+AcDbXrecord
+280
+     1
+ 70
+     1
+ 90
+429727718
+  1
+508B35C9-AEE7-456F-BE74-D52651303AC6
+310
+504B03040A0000080000B670623B3DEE336E79000000790000001B0000006175746F6465736B2D64657369676E2D7061636B6167652E786D6C3C3F786D6C2076657273696F6E3D22312E302220656E636F64696E673D227574662D3822203F3E3C666F726D6174733E3C666F726D61743E687474703A2F2F736368656D612E
+310
+6175746F6465736B2E636F6D2F64657369676E2D7061636B6167652F323030393C2F666F726D61743E3C2F666F726D6174733E504B0304140006080800B670623BD486FD9CA0000000F4000000130000005B436F6E74656E745F54797065735D2E786D6C7D8EC10E82300C865F65E91D8A1E8C310C0EEA1BF002731658846E
+310
+D98AC1B77784ABF1D8FE5FBFBF75BBCE937A534CCEB38643598122B6FEE978D0B0485F9C41B54DDD7D022595594E1A469170414C76A4D9A4D207E29CF43ECE46F218070CC6BECC4078ACAA135ACF422C856C0E68EA1BF5669944DDD7BCDE7B1F8E415D77AECB980613C2E4AC91FC167A2B244592486606FC29C8FD7F045B9A
+310
+EF7053A7E60B504B0304140006080800B670623B28ED286BEB0000007C01000008000000636F72652E786D6C8D90416EC3201045AF82665B6183218D6D61A254764FD00B204C5C94182C03558F5F9C3852BBEB6A467FFE9B197D71FA9E6FE8CBACC17AD7012D0820E3B41FAD9B3A48F1826B40272956EFE32F1B20A766D3C1
+310
+268314D3EAD3B24BDABB685CCCAAF3A3D94515828980F42D371D04FD696655A814B3235C8B45E9AB9A4C419F5D8653B2237A1CB163DE672FD6AC209BF3C08E0D1B30EB19C3FC9D72FCC6EB231EFA33EDE96BDD341517E5064B11EDFCBCAF57A3A2194156843498524CAA0FCA5B7268F9E185D42D21A2DCEC7FA0B48CFF8492
+310
+759155FBBB0F2C80A4F991FB408A72CB22977B50B96EB9C91F504B0304140006080800B670623B55019EA25F0000007C00000007000000636E782E786D6C4DCB3B0E80201045D1AD90E915ED2CF8AC45050C11660C8261F98AB1B07AC9C97D42D718D865D3E909258CFD00CCE24AC6E326A164D74DC0B4128928FF32603847
+310
+2BA13128B1252AC747C6BAB984FC68F0B87FE8960A5C09FE86CFB69FBA01504B0304140006080800B670623B7BC41AC871010000D40300000C0000006662782F636F72652E786D6CC553ED6E8320147D15C2DF4501B56B6D90A64BBB27D80B50A5CE54C120983EFEAE1F4DD7A56BBA5FF3879273EEE59E7310BE393735EA95
+310
+ED2AA333CC428A91D2B9292A5D66D8BB63B0C26823B835C67D2BC348CB46657880B1E0A535BE9DA1DC68A7B403549B42CDA0EC3AE530CA6B5864B8CB3F552343E91D5474A7B095F949962A6421D0502778E72C0840D390E18DC5F170E664C205F7BE2A66B62A605A75AC94C522DDEEE3651AEF837817C741F2CE92E02D592D
+310
+83FD6ECB76EC7595A651C2C9D02CB8AB9A8BBADC2AE954814544691A3016D0E883256BBA58278B17BA5A53CAC9507ED3E4DBE2C9265F691747B3DCA9ADC382819091F8E1162272A8933DE82182932144F88C09DF060D8140C84E1EEA8B8F1340BDCA9DB1093085F157AA97B557309586747CD0EF0B4EA64E983A6E0EAEEFCE
+310
+889E9EF17847386AA94B30211D2C0FDE0D3AF9A4610EAD5536E8DD1969631B593F67E381C33F5157F17725E5A636F6BF1491F980C8FC7B90E13E8A2F504B0304140006080800B670623B70102A487D0000009D0000000B0000006662782F636E782E786D6C4DCCD10A83201886E15B91FFDC95A5C30335ACCDFB886521330D
+310
+A76397BF1A1DECE883878F57749FD5A3B74D2F17830472A901D9F088930B8B849267CC01754AA418F3DF0D5018572BE160506249B16C274D761E8BCFBB7A179E27F65CB39A0F14D396184C9921B81F34C3ACA1B4B99ABB6E6F062A25AA5F69DF23ACBE504B0304140006080800B670623B3610CA3329010000120200003100
+310
+00006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F636F72652E786D6C8D515B6EC32010BC0AE22B55850D0E446E848992B43E412FE000495162B07854397EA176A4F62F3F2C9A9D991D58BEBB8F37F0AD7D30CE76905418026DA553C65E3A98E219B510EC04F7CEC5
+310
+3F3408EC30EA0E16180A7EF12E4D0B249D8DDAC68C5AA7F4020E21E80881BCE54B0783FCD2E3500D296646B856D320AFC34557A4CAEDCC133C449F0380794839A138B47B86DB2345744D7A44594FD0E1B867883594369BFE63BF7EEF793D0B054FC9A8456E548E63CE46FB674D8A58F068C6477CE9F510B582A2C1F80D1182
+310
+70F349E816B32D65AFB8DD62CCEB42FF274A937A52948C8DEB66893BCB021484D7734370E5D2E9F608A3EF93F3119479ABA0E50B14B8C298119A43CCC4FCFCECB8A18B6388CEE7EF5D5D4F994BD86CBBA182D76543B9FCAE2FD7B24DF103504B0304140006080800B670623B1B8617914E0100003303000030000000666278
+310
+2F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F636E782E786D6CD593C16EC32010447F0571AD6CE3D489D20813A9877E410FBD62D82434182CC055F3F75D1292E692438FBD206B7698593D61BEFD1E2DF982108D773D6D6B460938E5B571FB9ECE6957AD29D90A1EBC4F7736
+310
+4A9C1CA1A759A682EF839FA72269D8C9D92654AD71C72206887E0E0A22CAF926B15E498B01E0AA19451807D01A34B919F16B070157417138917400F2F6FA41FCF0092A45DEE414C19BDC21783E4BD39D891265658C3D8DEA00A3ACE59CBC8678ACB54CB26EEB6BD7839D7E9348BE70AD9C8321B9BCA7F9A4A26C542347DEE0
+310
+50F09802D22BA6749A800A394DD62899107273365E3C82CFC6A55557BC06C10774B7ABE7AEC3B0F34CF06446280E154026D0542C187BA9DAB6628BF7B6DBB0E5A65B3EB1F58631DE64BBE083F7B65CC218087E22CABB042E51D1F2268F1FE12B3EA24D40D63E9CFE00120194D60B9D5BC67FE6D39CDF37E20AF817881F504B
+310
+0304140006080800B670623BBFEF2E3B690500003C100000340000006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F6F626A656374732E786D6CAD575D739B3814FD2B0CFB0C98D84E931D4227B6938EA793B6534F3BFB90198F0099B001899144EAECAFDF231018B0
+310
+D37A3FFC609090EEE7B94757C1FB7D915B2F54C88CB31BDB7727B64559CC938CA53776A576CE956DBD0F03C1B9EA2DB32D460A7A63EB693B0C52C1ABD24C257447AA5C8D66EF177F5832A68CDA569C13296F6C193FD182B8A4523CA1F2D94D88226EBADBBBBEDB2C1C8A4D05299F46424B222853B014F30C52ACC6287F389C
+310
+D85E1878FA7B18E87FB36AFAF62AAFF667A83F635211161F291B8999FAB3D5DDC5FCDA99CF6653677679E13B8BFBC5CAF1DF4D27CBCBE5F2FAF6EE1A8AA51290642C117467871F101B91C581D77CEA2C36869F3229E68CD1B8F61F1ED6361B89092D294B90C78C4A68EB793D190E7D1D9BDEE7A91E1B95FDE9F3BCEAEFE809
+310
+6A6D6F9F7D4B79F4275C90E7A04248AA51D5C4C738DAE06F72885AC4796EBE65D22A88A22223B995679120E2D50EB1542F098381188D4EA111AE3DB043FF20AF6F2B4AE3D7D83D65E5AECA730D4D3BAC91BD05FEA992B565D95F549CD6069B90AB2A63EACA38A45E4B6A87D781574F86817E4C2FCCC72690D62E2729520E37
+310
+9BAF234797BAF6D62B3BFC781FED37BA1E4F2B2F052FA9501A3E80569BB8F6A9A364D4FA67654E6F803383981F82F21591FF84F23D9882BC896C3FDBCF8C162508933B2E0AE4C69DD43F6BD2BE38DDDBF10BF86CB4FA784D37F3AF16075E67EC9030DECA1FC0A55373F5DFF3378C591FA9BDF485C10B0A8C8BA909E5262639
+310
+A8E72163488806A595734C81CB77D1DE0ED7604A303B76913CEC0272F412782FF88EFF4636D8AA56DF7B322474C4B767303F625997056C7B032C473C592B36CEBD15F3F9FF5233B7ABCDC74D257624A60F8658567497B14CE1EC3C80B76FD02011038F9EE9EB0F2E12387A9C844D3F09855125116D1D731DF8B43D2CF4E0A0
+310
+79A020C6BE946BCE0B7EA1E1219331CD73C228AF5A2DDD31A4B1DA918CE91350854D40A71723140BFA92E94E62B0626016CEFA5864A50E5977E8753CEDBEE1CBB7F52780D20E17AF0BA0F5F9B02A3AD07DCC732EB6D1EBB661421BE0C39E21BABF0FE16D22EA6929407C8DE596724C88B749B6DB5512BC7B228ADFD7CB7EA6
+310
+3A22397E690BA8D5D8D4E40CEC8CDA23C2C0B7D5898640101CEC9C6D331CE328CB93CAFBBAC70A642DF70DF95155945B52F08AA973C23469FD69ADEF84F7BB18F983A8F8C90E37F5D35980B2139A1C523540813E824EF83448CF7C72B598CE97D7CEEDDDDD3B6736BFBC771677EF66CE6A7E7139F7A793E9EDF2B2B3A8B624
+310
+0CDA13AA5F8388264EC4A0129909F3B7F5A16CEDF08128E97D680ACA4B9BE7B7B58BB638F0B00700EF36AE8B32A705658A68F83EE897FC2B41573190D1CCAF0B92D233A47CFEB019D9809933F67DD1A5467F8CF69AD9A5AE859342D45355448C64F968A371DC2D596ADC6E43D93D1B466F877A64E2893E54F23C4B40388995
+310
+525E5005DA3983ED45412510D3EFCA13737B3863F74BD30F2A12E5B4B5E489A025CE25500DB855B11ACE5BBFA185D35DD48D8DC3CE7DC69F2944DB42AA6F6CF09BCA622ADD08C7A36E7C6AE18000BAB08E040135C2D21C9D75B3A91B77BB746C403F38018DFE6EC939DD92F16B40BC05294B9CDA035AAD6D330AE27FE4786B
+310
+8E45145EA34A75BE1C263A676A35A8ACC6297337400BF16C54EF515F3F77CB77EB3583889C754FFA29081AA98E2222ADEF05DA3E63D2EDEA8B8756C05A7FB6CABC4A91CBF325398202CC952E70A008A830324BA200D5E5EF8F5F04C75DB4B0EE3340E071C98B823333B83577596BF3849B69F2085AA0FAFA212F26BEFF5877
+310
+FDE622B28D88A42E49E43326DA82D31E8CB006401E1DA726059ECEC168F97A6599036306A135688F9AD2E61A6EA178F4CD51974A9F2CCB9F36FE5EBD14601068D9C3BF01504B0304140006080000B670623B000000000000000000000000350000006662782F42384135303843342D343331462D343546312D424341352D35
+310
+32343432364645413344462F76657274696365732E62696E504B0304140006080800B670623BF270F1330600000004000000360000006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F747269616E676C65732E62696E636660600000504B0304140006080000B67062
+310
+3B000000000000000000000000370000006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F617474726962757465732E62696E504B0304140006080800B670623B08DA0BD19000000041010000360000006662782F42384135303843342D343331462D343546312D4243
+310
+41352D3532343432364645413344462F6469726563746F72792E786D6C858F410AC3201045AF22B36F53E9A60B35CBEEBAE80D244E44489C6234F4F835464A48035D0DF398FF9F8AF63D0E6CC63039F212F8F9020C7D47C6792B21C5FE7403D62A1188E2E60C98D7234A5830286103A55745067B9D86B8A3CF9C7F90C11DE6
+310
+07FB144396D7B6A82D282E9A152AD114D5EF2CB866EEE831B8EEA07A7BB5A8D7D61A2BAAEB7FD5F70921FF497D00504B0304140006080800B670623B3B4606F3FE000000A00100003B0000006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F7265736F75726365732F
+310
+636F72652E786D6C8D504B6E833010BD0A9A6D65B08134808CA354A427E8052C332156828DFCA97AFC9A40A576D7CDCCE87D344F8F9FBEE647F689CE6B6B7A6039850C8DB2A336530F315C4903D94970676DF82583CCC8197B5861107C72362E3BA4AC096842428D1D7107A5F71820538F74F4E0D50D6799CB1892C2DFF345
+310
+AABB9C306779A2934E701F5C0A906D4FD609C2A1B7D129F4BCD858C163D4E3AED163FAA9AF1A1D88F67CA98E6D35906AA82A52BFB39ABCD5CD915C86331BD86BD3B665CD8BD52C78D0F34F46E550061C419494B6843142CB0F5677F4D0D58717DA7494F26295FF31C565FCA7296A13AA728FBBD93C0896823C09C18BB5AFB4
+310
+9E65A6BD762BBE01504B010214000A0000080000B670623B3DEE336E79000000790000001B00000000000000000000000000000000006175746F6465736B2D64657369676E2D7061636B6167652E786D6C504B01021400140006080800B670623BD486FD9CA0000000F40000001300000000000000000000000000B2000000
+310
+5B436F6E74656E745F54797065735D2E786D6C504B01021400140006080800B670623B28ED286BEB0000007C010000080000000000000000000000000083010000636F72652E786D6C504B01021400140006080800B670623B55019EA25F0000007C000000070000000000000000000000000094020000636E782E786D6C50
+310
+4B01021400140006080800B670623B7BC41AC871010000D40300000C00000000000000000000000000180300006662782F636F72652E786D6C504B01021400140006080800B670623B70102A487D0000009D0000000B00000000000000000000000000B30400006662782F636E782E786D6C504B01021400140006080800B6
+310
+70623B3610CA3329010000120200003100000000000000000000000000590500006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F636F72652E786D6C504B01021400140006080800B670623B1B8617914E010000330300003000000000000000000000000000D10600
+310
+006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F636E782E786D6C504B01021400140006080800B670623BBFEF2E3B690500003C10000034000000000000000000000000006D0800006662782F42384135303843342D343331462D343546312D424341352D35323434
+310
+32364645413344462F6F626A656374732E786D6C504B01021400140006080000B670623B0000000000000000000000003500000000000000000000000000280E00006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F76657274696365732E62696E504B010214001400
+310
+06080800B670623BF270F133060000000400000036000000000000000000000000007B0E00006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F747269616E676C65732E62696E504B01021400140006080000B670623B00000000000000000000000037000000000000
+310
+00000000000000D50E00006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F617474726962757465732E62696E504B01021400140006080800B670623B08DA0BD1900000004101000036000000000000000000000000002A0F00006662782F42384135303843342D3433
+310
+31462D343546312D424341352D3532343432364645413344462F6469726563746F72792E786D6C504B01021400140006080800B670623B3B4606F3FE000000A00100003B000000000000000000000000000E1000006662782F42384135303843342D343331462D343546312D424341352D3532343432364645413344462F72
+310
+65736F75726365732F636F72652E786D6C504B0506000000000E000E0080040000651100000000
+  0
+XRECORD
+  5
+187
+102
+{ACAD_REACTORS
+330
+186
+102
+}
+330
+186
+100
+AcDbXrecord
+280
+     1
+ 70
+     1
+ 90
+429727718
+  1
+887D55A9-D0DD-414E-B741-A7DCD4DA2B4C
+310
+504B03040A0000080000B670623B3DEE336E79000000790000001B0000006175746F6465736B2D64657369676E2D7061636B6167652E786D6C3C3F786D6C2076657273696F6E3D22312E302220656E636F64696E673D227574662D3822203F3E3C666F726D6174733E3C666F726D61743E687474703A2F2F736368656D612E
+310
+6175746F6465736B2E636F6D2F64657369676E2D7061636B6167652F323030393C2F666F726D61743E3C2F666F726D6174733E504B0304140006080800B670623BD486FD9CA0000000F4000000130000005B436F6E74656E745F54797065735D2E786D6C7D8EC10E82300C865F65E91D8A1E8C310C0EEA1BF002731658846E
+310
+D98AC1B77784ABF1D8FE5FBFBF75BBCE937A534CCEB38643598122B6FEE978D0B0485F9C41B54DDD7D022595594E1A469170414C76A4D9A4D207E29CF43ECE46F218070CC6BECC4078ACAA135ACF422C856C0E68EA1BF5669944DDD7BCDE7B1F8E415D77AECB980613C2E4AC91FC167A2B244592486606FC29C8FD7F045B9A
+310
+EF7053A7E60B504B0304140006080800B670623BBC1638F5EC0000007C01000008000000636F72652E786D6C8D90416EC3201045AF82665B61836BE2D8C24471DB9CA01740401C94182C03558F5F9C3852BBEB6A467FFE9B197D7EF89E6EE8CB2CC17AD7032D0820E394D7D68D3DA478C67B4007C117EFE32F1B202727D3C3
+310
+2A83E0E3E2D3BC49CABB685CCCAAF3DA6CA20CC14440EA969B1E82BA98491632C5EC08D76296EA2A4753D06797E194AC468F2356E77DF66CCD02825543D50CACC62D39ED70FDC68EB8FD68F6F8787A6784342D1DDA1D2F5758F068A7E77DB518198D065111D2624A31A93E69DD11D6D5EC85EC3B4278B9DAFF4069D6FF8492
+310
+75F1B5DADE7D600104CD8FDC0782976B16B9DC83CA75CD4DFC00504B0304140006080800B670623B55019EA25F0000007C00000007000000636E782E786D6C4DCB3B0E80201045D1AD90E915ED2CF8AC45050C11660C8261F98AB1B07AC9C97D42D718D865D3E909258CFD00CCE24AC6E326A164D74DC0B4128928FF326038
+310
+472BA13128B1252AC747C6BAB984FC68F0B87FE8960A5C09FE86CFB69FBA01504B0304140006080800B670623B3586FFB671010000D40300000C0000006662782F636F72652E786D6CC553ED6E8320147D15C2DF4541A76D6D90A6DDD627D80B50A4CE54C120983EFEAE1F4DD7A55BBA5FF3879273EEE59E7310B6393735EA
+310
+95ED2AA3731C851423A5A5292A5DE6D8BB63B0C268C39935C67D29C3488B46E578803167A535BE9D2169B453DA01AA4DA16650749D7218C91A1639EEE4876A4428BC838AEE14B6429E44A9C228041AEA38EB9C0501681A32BC313F1ECE8C4C3867DE57C5CC56054CAB8E95B298A7F12E5EEED224C8E87E11242FE936C8DE96
+310
+AB60BB7F4D295D66D12E5B30323473E6AAE6A24E5A259C2A308F29CD82280A68FC1E256B9AAE93F489AED694323294DF34F9B678B0C957DA3DC7B3DCA9ADC33C022123F1CD2D44E450277AD04338234388F01913BE0D1A0281909D38D4171F27807A259DB1093085F157AA17B557309586747CD0CF0B46A64E983A6E0EAEEF
+310
+CE881F9EF1FB8E70D44297604238581EBC1B74B249C31C5AAB6CD0BB33D2C636A27ECCC62F0EFF445DC5DF95244D6DEC7F2922F30191F9F720C37DE49F504B0304140006080800B670623B4220A0FF7D0000009D0000000B0000006662782F636E782E786D6C4DCCD10A83201886E15B91FFDCE542CB0335D0EC3E6259C84A
+310
+C3E9D8E5AF46073BFAE0E1E315DD675BD1DBA5978F41C2FD4600B9F088930F8B849267CC01754AA418F3DF0D50183727E164506249B1EC174D6E1ECB9A0F5D7D785E68DB8151CD286E5A5363CA6B8A39E90D36D40E96B086F55A43A544F52B1D7B86D517504B0304140006080800B670623B2FA3FEDE290100001202000031
+310
+0000006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F636F72652E786D6C8D515B6EC32010BC0AE22B55850D2E386E848994D7097A0117488A1283C5A3CAF10BB523B57FF961D1ECCCECC0F2ED7DBC816FED8371B687A4C210682B9D32F6D2C314CFA883602BB8772E
+310
+FEA141608751F7B0C050F08B77695A20E96CD43666D43AA5177008414708E42D5F7A18E4971E876A483133C2B59A06791D2EBA22556E679EE021FA1C00CC43CA09C5717D6274C7286AD7FB06D1AEA1A8C3873DDAD3E3E98859CB0EBB1DAF67A1E02919B5C88DCA71CCD968FFAC49110B1ECDF8882FBD1EA256503418BF2342
+310
+106E3E08DD60B6A1EC15771B8C795DE8FF4469524F8A92B1F1AD59E2CEB20005E1F5DC105CB9F4797B84D1F7C9F908CABC55D0F2050A5C61CC1AD2F27A26E6E767C7962E8E213A9FBF7775FDCC5CC266DB960A5E970DE5F2BBBE5CCB36C50F504B0304140006080800B670623B1B8617914E01000033030000300000006662
+310
+782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F636E782E786D6CD593C16EC32010447F0571AD6CE3D489D20813A9877E410FBD62D82434182CC055F3F75D1292E692438FBD206B7698593D61BEFD1E2DF982108D773D6D6B460938E5B571FB9ECE6957AD29D90A1EBC4F77
+310
+364A9C1CA1A759A682EF839FA72269D8C9D92654AD71C72206887E0E0A22CAF926B15E498B01E0AA19451807D01A34B919F16B070157417138917400F2F6FA41FCF0092A45DEE414C19BDC21783E4BD39D891265658C3D8DEA00A3ACE59CBC8678ACB54CB26EEB6BD7839D7E9348BE70AD9C8321B9BCA7F9A4A26C542347DE
+310
+E050F09802D22BA6749A800A394DD62899107273365E3C82CFC6A55557BC06C10774B7ABE7AEC3B0F34CF06446280E154026D0542C187BA9DAB6628BF7B6DBB0E5A65B3EB1F58631DE64BBE083F7B65CC218087E22CABB042E51D1F2268F1FE12B3EA24D40D63E9CFE00120194D60B9D5BC67FE6D39CDF37E20AF817881F50
+310
+4B0304140006080800B670623B29652116630500003C100000340000006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F6F626A656374732E786D6CAD575D739B3814FD2B0CFB0C989834C90EA1639B24E3E9A6EDD4D3CE3E64C623834CD8006224913AFDF57B040203
+310
+B65BEF871F0C12D2FD3CF7E8CA7FBFCB33E3957291B2E2D674ED8969D02262715A24B76625B7D6B569BC0F7CCE98EC2D338D82E4F4D654D366E0279C55A59E8AE99654991CCDDECFFF3444440B6A1A514684B83545F44C7362934AB2988A173B2692D8C97667BB76B3702836E1A47C1E092D09A78584A5982F20C5688C7287
+310
+C389E904BEA3BE07BEFAD7ABA6A75739B53F43FD69212429A20365233153D70BEF2E2E6FAC4BCF9B5ADEBB0BD79ADFCF43CBBD9A4E16EF168B9BD9DD0D140BC921495BC2E9D60C1E101B9E46BED37CEA2CD6861F3329624541A3DA7F7858DBAC25C6B4A4458C3CA654405BCFEBC970E8AAD8F43E4FD558ABEC4F9FE7557F47
+310
+4F506B7BFBEC5BCA367FC105710E2AB8A00A554D7CB4A30DFE26FBA86D18CBF4B75418399194A72433B274C3097F33032C554B027F2046A1932B842B0FCCC0DDCBEBDB8AD2F835768F59B9ADB24C41D30C6A64AF817F2A456D59FA83F2E3DA60137255A585BCD60EC9B7929AC18DEFD49381AF1ED30BFDB109A4B1CD488294
+310
+C3CDE6EBC8D185AABD6568061FEE37BB95AAC7E3CA4BCE4ACAA5820FA0D526AE7DAA2869B5EE5999531BE0CC20E6FBA07C41E43FA27CF7A6206F3CDD793B4F6B919C1462CB788EDCD893FA674CDA17AB7B3B7C019F8D561FAEE966FED562DFE98C1D12C6A9FC015C2A35D7FF3D7FC398F591DA4B5FE0BFA2C0189FEA50AE22
+310
+92817A1ED3020951A03432862970F976B33383259812CC8E5D240BBA801CBCF8CE2BBEE3BF910DB6AAD5F79E05123AE2DB33981FB1ACCB02B69D00CB014FD68AB573A7627EF9BFD4CC2C5C7D58557C4B22FAA88925A4DBB44825CECE3D78FB060D1231F0E885BE7D673C86A3874958F593906B5502D1563157814FDAC3420D
+310
+F69A070A22EC4B98E23CFF171A1E5311D12C23056555ABA53B8614563B92D17D02AAB009E8F46284624E5F53D5490C560CCCC2591FF1B45421EB0EBD8EA7ED13BE7C5D7E0428CD60FEF60779EB13E6664FF711CB185F6FDED60D139A001FF60CD1FD6D086F1D51474901E26B2CB794A343BC8ED3EDB612E0DD2351FCB65CF4
+310
+33D511C9E14B5B40ADC6A6263DB0336A8F700DDF56271A024E70B0B3629DE21847591E55DED73D56206AB927E46FAABC5C939C55853C274C93D69FD6FA4E78BF8B11DF898C9ECD60553FAD39283BA6F18984AA23E8884F83F45C5F5F859797B31B2B9C84A1E5B9DE9D35BFF25C6B76152E422F9C5DCC3D847F5801ED09D5AF
+310
+41441327A25FF15487F9EB725FB666F048A4701E9A827292E6F97569A32DF61DEC01C0BB8DCBBCCC684E0B49147C1FD54BF685A0AB18C868E6973949E819523E3DAC463660E68C7D9F55A9D1EFA3BD7A76A16AE1A810F95CE59B82A4D968A376DC2E8B44BBDD86B27B368CDE0ED548C7137DA860591A83706223A12CA712B4
+310
+7306DBF39C0A20A6DF95C7FAF670C6EED7A61F946493D1D6926782963813403548A78AE470DEF80D2D9CEAA26E4D1C76F60BFE74219A06527D6B82DF641A51616F703CAAC6A7160E08A00BEB4810A0274592A1B36E3675E36E978A0DE80727A0D6DF2D39A75BD27E0D8837276589537B40ABB56D5A41F48F1C6FCD3188C4EB
+310
+A6929D2FFB89CE995A4D00AE813BDD032DC48B56BD437DFDDC2DD7AED70C2272D63DE9A72068A45A92F0A4BE17A8A06B9366E16707AD80B1FC649459952097E74BB23805982B55E0401150A165964402AA8BDF9F3E7386BB686EDCA780C0D382E5392BF460A6EFB2C6EA1937D3F809B440D5F5435C4C5CF7A9EEFAF54564BD
+310
+2182DA24162F98680B4E7930C21A0079709CEAEB99A372305ABE0C0D7D6078105A83F6A0296DAEE1068A47DD1C55A9F4C9B2FC69E3EFD44B81028E963DF81B504B0304140006080000B670623B000000000000000000000000350000006662782F45374635344235342D363743322D343832342D383044432D433445464530
+310
+3536354442422F76657274696365732E62696E504B0304140006080800B670623BF270F1330600000004000000360000006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F747269616E676C65732E62696E636660600000504B0304140006080000B670623B00000000
+310
+0000000000000000370000006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F617474726962757465732E62696E504B0304140006080800B670623B08DA0BD19000000041010000360000006662782F45374635344235342D363743322D343832342D383044432D4334
+310
+454645303536354442422F6469726563746F72792E786D6C858F410AC3201045AF22B36F53E9A60B35CBEEBAE80D244E44489C6234F4F835464A48035D0DF398FF9F8AF63D0E6CC63039F212F8F9020C7D47C6792B21C5FE7403D62A1188E2E60C98D7234A5830286103A55745067B9D86B8A3CF9C7F90C11DE607FB144396
+310
+D7B6A82D282E9A152AD114D5EF2CB866EEE831B8EEA07A7BB5A8D7D61A2BAAEB7FD5F70921FF497D00504B0304140006080800B670623B6378F24DFF000000A00100003B0000006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F7265736F75726365732F636F72652E
+310
+786D6C8D504B6E833010BD0A9A6D65B0094E42641C85B639412F6099496225D8C89FAAC7AF09546A77DDCC8CDE47F3F4C4F16B7C149FE88371B603565228D06A37187BED20C50BD9437194C23B177FC9A0B06AC40E6618A4B87A97A615D2CE46B431A3D60DB8822A048C50E8473E3A08FA86A32A558A5911EEE5A4F45D5DB1
+310
+6465A6B34E8A107D0E502C4FE609D26370C96B0CA25A58295232C3AA3143FE692E063D485EF7F5AEE71BD2D2F39634AFFC44DAF7DD9E9CCE6F9CD25DCBFA762BAAD92C4534E34F46ED51451C40D694B6843142EB0FD61C283F34FC85EE0F948A6A96FF31A569F8A729191B37F51A77B105902C0779125254735F793DCBCC7B
+310
+EE567E03504B010214000A0000080000B670623B3DEE336E79000000790000001B00000000000000000000000000000000006175746F6465736B2D64657369676E2D7061636B6167652E786D6C504B01021400140006080800B670623BD486FD9CA0000000F40000001300000000000000000000000000B20000005B436F6E
+310
+74656E745F54797065735D2E786D6C504B01021400140006080800B670623BBC1638F5EC0000007C010000080000000000000000000000000083010000636F72652E786D6C504B01021400140006080800B670623B55019EA25F0000007C000000070000000000000000000000000095020000636E782E786D6C504B010214
+310
+00140006080800B670623B3586FFB671010000D40300000C00000000000000000000000000190300006662782F636F72652E786D6C504B01021400140006080800B670623B4220A0FF7D0000009D0000000B00000000000000000000000000B40400006662782F636E782E786D6C504B01021400140006080800B670623B2F
+310
+A3FEDE290100001202000031000000000000000000000000005A0500006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F636F72652E786D6C504B01021400140006080800B670623B1B8617914E010000330300003000000000000000000000000000D2060000666278
+310
+2F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F636E782E786D6C504B01021400140006080800B670623B29652116630500003C10000034000000000000000000000000006E0800006662782F45374635344235342D363743322D343832342D383044432D4334454645303536
+310
+354442422F6F626A656374732E786D6C504B01021400140006080000B670623B0000000000000000000000003500000000000000000000000000230E00006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F76657274696365732E62696E504B01021400140006080800
+310
+B670623BF270F13306000000040000003600000000000000000000000000760E00006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F747269616E676C65732E62696E504B01021400140006080000B670623B0000000000000000000000003700000000000000000000
+310
+000000D00E00006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F617474726962757465732E62696E504B01021400140006080800B670623B08DA0BD190000000410100003600000000000000000000000000250F00006662782F45374635344235342D363743322D34
+310
+3832342D383044432D4334454645303536354442422F6469726563746F72792E786D6C504B01021400140006080800B670623B6378F24DFF000000A00100003B00000000000000000000000000091000006662782F45374635344235342D363743322D343832342D383044432D4334454645303536354442422F7265736F75
+310
+726365732F636F72652E786D6C504B0506000000000E000E0080040000611100000000
+  0
+XRECORD
+  5
+112
+102
+{ACAD_REACTORS
+330
+110
+102
+}
+330
+110
+100
+AcDbXrecord
+280
+     1
+270
+     1
+271
+     1
+  0
+XRECORD
+  5
+111
+102
+{ACAD_REACTORS
+330
+110
+102
+}
+330
+110
+100
+AcDbXrecord
+280
+     1
+270
+     1
+271
+     1
+  0
+XRECORD
+  5
+18A
+102
+{ACAD_REACTORS
+330
+110
+102
+}
+330
+110
+100
+AcDbXrecord
+280
+     1
+ 70
+     0
+ 90
+1778669749
+  1
+9BF507EE-FAF7-4A99-A33D-4EE51894BC40
+310
+504B03040A0000080000B670623B3DEE336E79000000790000001B0000006175746F6465736B2D64657369676E2D7061636B6167652E786D6C3C3F786D6C2076657273696F6E3D22312E302220656E636F64696E673D227574662D3822203F3E3C666F726D6174733E3C666F726D61743E687474703A2F2F736368656D612E
+310
+6175746F6465736B2E636F6D2F64657369676E2D7061636B6167652F323030393C2F666F726D61743E3C2F666F726D6174733E504B0304140006080800B670623BD486FD9CA0000000F4000000130000005B436F6E74656E745F54797065735D2E786D6C7D8EC10E82300C865F65E91D8A1E8C310C0EEA1BF002731658846E
+310
+D98AC1B77784ABF1D8FE5FBFBF75BBCE937A534CCEB38643598122B6FEE978D0B0485F9C41B54DDD7D022595594E1A469170414C76A4D9A4D207E29CF43ECE46F218070CC6BECC4078ACAA135ACF422C856C0E68EA1BF5669944DDD7BCDE7B1F8E415D77AECB980613C2E4AC91FC167A2B244592486606FC29C8FD7F045B9A
+310
+EF7053A7E60B504B0304140006080800B670623BCA089DFFEC0000007C01000008000000636F72652E786D6C8D90416E83301045AF62CDB632D8402020E32882F604BD80653BC44AB011B6AB1EBF262152BBEB6A467FFE9B197D76FA9EEFE84BAFDE38DB03CD08206DA553C64E3DC470C1474027CE56E7C22F1B202B66DDC3
+310
+260367D3EAE2B24BD2D9A06D48AA754AEFA2F05E0740F29E9A1EBCBCEA59642286E4F0B76C11F226269DD15797E0188D42CF2346A57DE662F40ABCAEC77628C6120F654571D50C04B7F5B9C1E3997CD4F550BE3745C3F20DE62C98F9755FAE5A04AD801784B498524C8A4F5A75E4D055873772EC0861F966FF03C545FD138A
+310
+C686B2D8DF7D621E384D8F3C069CE55B16A93C824A75CB8DFF00504B0304140006080800B670623B55019EA25F0000007C00000007000000636E782E786D6C4DCB3B0E80201045D1AD90E915ED2CF8AC45050C11660C8261F98AB1B07AC9C97D42D718D865D3E909258CFD00CCE24AC6E326A164D74DC0B4128928FF326038
+310
+472BA13128B1252AC747C6BAB984FC68F0B87FE8960A5C09FE86CFB69FBA01504B0304140006080800B670623B68FC0B7272010000D40300000C0000006662782F636F72652E786D6CC5535B6E833010BC8AE5DF0A6C1E8124328E22D29EA01770C0A128602363A31CBFCB234A53A555FA553EC09AD9F5CE8C31DB5DDA060D
+310
+D2F4B556190E7C8A9154852E6B5565D8D993B7C668C799D1DA7E29C3488956667884316795D1AE5BA0422B2B950554E9522EA0E87B69312A1A5864B82F3E642B7CE12C54F467BF13C55954D20F7CA0A18EB3DE1A1080E621E31BF3D3F1C2C88C73E65C5D2E6C5DC2B4FA544B8379921C36797888BC3C8A032F4E73EA6D927D
+310
+EA1DF6F42D49F2E8350D5346C666CE6CDD5ED515460A2B4BCC434A375E1078347C0FE22D5D6DE3D50B5D6F2965642CBF6B725DF96493AB958DC245EEDCD6631E809089F8E61622B2A81703E8219C913144F84C09DF070D8140C8561C9BAB8F3340832CAC363130A576376A108D933095FA747AD0CF0B46E64E983A6D0EAE1F
+310
+CE089F9EF1FB8E70D44255604258581E9D1D75B259C3125A278D37D80B52DAB4A279CEC62F0EFF44DDC43F9454E8469BFF5244960322CBEF41C6FBC83F01504B0304140006080800B670623B0F71DDB67E0000009D0000000B0000006662782F636E782E786D6C4DCCD10A83201886E15B91FFDCA54DB73F502386BB8F5816
+310
+32D3703976F9ABD1C18E3E78F87855FB990379BBFCF2296AE02706C4C5471A7C9C349475A408A4352AA7B4FEDD80C47E761A7606A3A69CCA72D0E0C6BE8475D3E0E3F3409428EA6B27A84079A782899AA2EC1A7AE3ECCC2FD858CB2D544655BFD2B67BD87C01504B0304140006080800B670623BE134B4FB28010000120200
+310
+00310000006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F636F72652E786D6C8D515B6EC32010BC0AE22B55850D0EA424C24451959EA0172086A42831583CAA1CBF503B52FB971F16CDCECC0EACD8DFC71BF836215AEF7A481A0C817183D7D65D7A98D3197108F652
+310
+04EFD31F1A044E8DA6871586525C82CFD3020DDE25E352419DD76601558C264130DCCAA58771F832A36A544E8511AFCDA486ABBA988634A55D7852C4144A00300FA927949C71DABD1D28A29C7D208A6987383B6CD13BC16BB2E1DBE3911C453B0BA5C8D9EA456E758963CFD684674DAA588A64C747FC2118958C86B2C3788B
+310
+0841B8FB247487D98EB257CC77188BB6D2FF89F2A49F1465EBD2BA5BE2CEB2082511EDDC9042FB7CBA3DC298FBE4430275DE2A9AE1054ADC60CC08E3A29D89E5F9C5714317C7987C28DFBBBA9E0A97B0D97643A568EB864AF95D5FA9759BF207504B0304140006080800B670623B1B8617914E010000330300003000000066
+310
+62782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F636E782E786D6CD593C16EC32010447F0571AD6CE3D489D20813A9877E410FBD62D82434182CC055F3F75D1292E692438FBD206B7698593D61BEFD1E2DF982108D773D6D6B460938E5B571FB9ECE6957AD29D90A1EBC4F
+310
+77364A9C1CA1A759A682EF839FA72269D8C9D92654AD71C72206887E0E0A22CAF926B15E498B01E0AA19451807D01A34B919F16B070157417138917400F2F6FA41FCF0092A45DEE414C19BDC21783E4BD39D891265658C3D8DEA00A3ACE59CBC8678ACB54CB26EEB6BD7839D7E9348BE70AD9C8321B9BCA7F9A4A26C542347
+310
+DEE050F09802D22BA6749A800A394DD62899107273365E3C82CFC6A55557BC06C10774B7ABE7AEC3B0F34CF06446280E154026D0542C187BA9DAB6628BF7B6DBB0E5A65B3EB1F58631DE64BBE083F7B65CC218087E22CABB042E51D1F2268F1FE12B3EA24D40D63E9CFE00120194D60B9D5BC67FE6D39CDF37E20AF817881F
+310
+504B0304140006080800B670623B5933D422630500003B100000340000006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F6F626A656374732E786D6CAD575B6FA33814FE2B887D0642934E9B156594264D158D3A534DD4D13E548A0C38942D60649B4EBABF7E3F8321
+310
+40924EF6928780CDF1B97EE762EFF32E4B8D37CA45C2F21BD3B547A641F39045491EDF98A5DC5AD7A6F1D9F73863B243661A39C9E88DA9B64DDF8B392B0BBD15D12D295339D85DDEFE618890E6D434C2940871638AF08566C426A5641115AF764424B1E3EDCE76ED9AB0CF36E6A47819302D08A7B984A6D8CFC1C5A89572FB
+310
+CB91E9F89EA3BEFB9EFAD754E3D3544E654F5F7E920B49F2F040D880CDD89D2CEE2E2EA7D6E56432B6269F2E5CEB7679BBB0DCABF168FE693E9FCEEEA6102C240727AD09A75BD3BF876F78127A4EFDA9D5582B7E4CA590E5390D2BFB6161A5B3E618D182E611E2985001691DAB47FDA5AB7CD3F93C566B2DB2BB7D9E55DD13
+310
+1D468DEECDB3AB290BFE8409E21C54704115AA6AFF68436BFC8DF65E0B184BF5B74418199194272435D224E084BF9B3E481589EFF5D828747285706581E9BB7B7E5D5D911ABFC6EE312DB7659A2A689A7E85EC0DF04FA5A8344BFEA2FCB834E8845895492EAFB541F2BDA0A63FF59C6AD3F7D4637CA13FD68E34B629891172
+310
+98597F1D183A57B9B75A98FE9765B05BAB7C3C2EBCE0ACA05C2AF8005A4DE09AA7F29216EB9E15397500C6F47CBE77CA7778FE2BD277AF0AE2C693DD6437D1522427B9D8329E2136F6A8FA19A3E6C56ADF0E5F50CF06D48734EDCEBF22F69C56D97EC138153F804B85E6FABFC7AFEFB32E523BE1F3BD372418E363EDCA7548
+310
+52949E8724474014288D94610BB57C1BEC4C7F854A89CA8E5324F55B871CBC78CE1BBEE3BFE68D6A5589EF3C730474506FCFA8FCF0659516D0ED04580EEA6425581B77CAE797FF4BCECC16EB2FEB926F49481F746159D06D922712BD730FDEAE42BD40F42C7AA5EF3F198F60E86110D6DD20645A9480B795CF95E3E3A659A8
+310
+C55E724F408873315335CFFB8584874484344D494E59D94869DB90C26A5B64F49C802CAC1D3ABE18A098D3B7444D123D8A9E5AE8F5214F0AE5B2B6E9B575DA3E61CBD3EA2B4009FA940524DD1305FB6A1FB294F14DF0BEA90BA109ECE1481FDC3FFAE8D60E75141700BE82725371B4873751B2DD960265F788137FACE6DD40
+310
+B575E4F0A5C99F46629D92131467A41EE11ABD8D4CCC039CA0AFB37C93A08B232B8F0AEFCA1E0A1015DF13FC83322B362463652ECF71D3A8B1A7D1BE65DE1D62C44F22C317D35F574FEB16153BA2D13E543D10A80E74C4A65E78A6B7CBCBD1D5DD9DB59C2DAFACC96C3AB566E3F1C29ADCDD5DBAD7D3C9ED7C822ED74F80A6
+310
+41755310DE4443F44A9E68373FADF6596BFA0F440AE7BECE2727AE9F4F2B1B53B1E7E00CF0DD1E5C65454A339A4BA2D0FBA05ED2EF0443458F47BDBFCA484CCFE0F2ED7E3DD0013B679C7B5499467F0ECEEADDB9CA85A34CE44B99053949D2C1416DB85DE4B136BB7165FBAC0B7AB3542BED4F8CA182A549847A1319316519
+310
+95A83A67147B9E5101C47487F2485F1ECE38FD568F839204296D3479219888530154036E6528FBFBC66F98E0D4107563A2D7D9AFF8D389681A08F58D89F22693900A3B407754734FC51C10C010D6D640809EE4718AC1BA3ED4AEDB53CA37283F68805A7E4B72CEB0A4EDEAD5DD8C14059A76AFAA56BA6901E13F32BC51C720
+310
+12AF41295B5BF61BAD3195181FB506E6B40F4C10AF5AF40EF9F5B159AE5DD1F43C72D635E94310D45C2D49785C5D0B94D3B54AB3C5A38349C0587D338AB48C11CBF339599C02CCA54A70A008A8D03C0B2201D5F9EFCF8F9CE12A9A19CB0410789EB32C63B95ECCF455D658BFE0621A3DA32C5075FB101723D77DAE867E7D0F
+310
+D90444509B44E2151B4DC2290B065803200FBAA9BE9D392A0603F2D5C2D00D6302A615680F66D2FA166E2079D4C551A54AB758161FCEFD4E450A14704CECFEDF504B0304140006080000B670623B000000000000000000000000350000006662782F38353834323741342D343835462D343034322D383541392D4331303331
+310
+363839454531452F76657274696365732E62696E504B0304140006080800B670623BF270F1330600000004000000360000006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F747269616E676C65732E62696E636660600000504B0304140006080000B670623B000000
+310
+000000000000000000370000006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F617474726962757465732E62696E504B0304140006080800B670623B08DA0BD19000000041010000360000006662782F38353834323741342D343835462D343034322D383541392D43
+310
+31303331363839454531452F6469726563746F72792E786D6C858F410AC3201045AF22B36F53E9A60B35CBEEBAE80D244E44489C6234F4F835464A48035D0DF398FF9F8AF63D0E6CC63039F212F8F9020C7D47C6792B21C5FE7403D62A1188E2E60C98D7234A5830286103A55745067B9D86B8A3CF9C7F90C11DE607FB1443
+310
+96D7B6A82D282E9A152AD114D5EF2CB866EEE831B8EEA07A7BB5A8D7D61A2BAAEB7FD5F70921FF497D00504B0304140006080800B670623BD9A3B367FE000000A00100003B0000006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F7265736F75726365732F636F7265
+310
+2E786D6C8D504B6E833010BD0A9A6D65B01D0201194711694FD00B586642AD043BF2A7EAF16B122AB5BB6E6646EFA3797AE2F8B5DC8A4FF4C1383B002B291468B59B8C9D0748F1420E501CA5F0CEC55F3228AC5A708015062966EFD27D83B4B3116DCCA875136EA00A012314FA968F0182FEC045952AC5AC08D7F2AEF455CD
+310
+58B232D3592745883E07289E4FD609D26370C96B0CA27AB252A464A64D63A6FCD35C0C7A904D73EE467EE664DCD58CD4ED4849D79C5A723ED1B7A61977AF2D6F45B59AA58866F9C9A83DAA8813484E6947182394BFB3BAA7FBBEDEBFD0434FA9A856F91F53BA4FFF342563E38E6F719FB60092E5200F428A6AED2BAF479979
+310
+AFDDCA6F504B010214000A0000080000B670623B3DEE336E79000000790000001B00000000000000000000000000000000006175746F6465736B2D64657369676E2D7061636B6167652E786D6C504B01021400140006080800B670623BD486FD9CA0000000F40000001300000000000000000000000000B20000005B436F6E
+310
+74656E745F54797065735D2E786D6C504B01021400140006080800B670623BCA089DFFEC0000007C010000080000000000000000000000000083010000636F72652E786D6C504B01021400140006080800B670623B55019EA25F0000007C000000070000000000000000000000000095020000636E782E786D6C504B010214
+310
+00140006080800B670623B68FC0B7272010000D40300000C00000000000000000000000000190300006662782F636F72652E786D6C504B01021400140006080800B670623B0F71DDB67E0000009D0000000B00000000000000000000000000B50400006662782F636E782E786D6C504B01021400140006080800B670623BE1
+310
+34B4FB280100001202000031000000000000000000000000005C0500006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F636F72652E786D6C504B01021400140006080800B670623B1B8617914E010000330300003000000000000000000000000000D3060000666278
+310
+2F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F636E782E786D6C504B01021400140006080800B670623B5933D422630500003B10000034000000000000000000000000006F0800006662782F38353834323741342D343835462D343034322D383541392D4331303331363839
+310
+454531452F6F626A656374732E786D6C504B01021400140006080000B670623B0000000000000000000000003500000000000000000000000000240E00006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F76657274696365732E62696E504B01021400140006080800
+310
+B670623BF270F13306000000040000003600000000000000000000000000770E00006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F747269616E676C65732E62696E504B01021400140006080000B670623B0000000000000000000000003700000000000000000000
+310
+000000D10E00006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F617474726962757465732E62696E504B01021400140006080800B670623B08DA0BD190000000410100003600000000000000000000000000260F00006662782F38353834323741342D343835462D34
+310
+3034322D383541392D4331303331363839454531452F6469726563746F72792E786D6C504B01021400140006080800B670623BD9A3B367FE000000A00100003B000000000000000000000000000A1000006662782F38353834323741342D343835462D343034322D383541392D4331303331363839454531452F7265736F75
+310
+726365732F636F72652E786D6C504B0506000000000E000E0080040000611100000000
+  0
+XRECORD
+  5
+113
+102
+{ACAD_REACTORS
+330
+110
+102
+}
+330
+110
+100
+AcDbXrecord
+280
+     1
+270
+     1
+271
+     1
+  0
+XRECORD
+  5
+114
+102
+{ACAD_REACTORS
+330
+110
+102
+}
+330
+110
+100
+AcDbXrecord
+280
+     1
+270
+     1
+271
+     1
+  0
+CELLSTYLEMAP
+  5
+23F
+102
+{ACAD_REACTORS
+330
+104
+102
+}
+330
+104
+100
+AcDbCellStyleMap
+ 90
+        3
+300
+CELLSTYLE
+  1
+TABLEFORMAT_BEGIN
+ 90
+        5
+170
+     1
+ 91
+        0
+ 92
+    32768
+ 62
+   257
+ 93
+        1
+300
+CONTENTFORMAT
+  1
+CONTENTFORMAT_BEGIN
+ 90
+        0
+ 91
+        0
+ 92
+      512
+ 93
+        0
+300
+
+ 40
+0.0
+140
+1.0
+ 94
+        5
+ 62
+     0
+340
+11
+144
+0.25
+309
+CONTENTFORMAT_END
+171
+     1
+301
+MARGIN
+  1
+CELLMARGIN_BEGIN
+ 40
+0.06
+ 40
+0.06
+ 40
+0.06
+ 40
+0.06
+ 40
+0.18
+ 40
+0.18
+309
+CELLMARGIN_END
+ 94
+        6
+ 95
+        1
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+        2
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+        4
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+        8
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+       16
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+       32
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+309
+TABLEFORMAT_END
+  1
+CELLSTYLE_BEGIN
+ 90
+        1
+ 91
+        1
+300
+_TITLE
+309
+CELLSTYLE_END
+300
+CELLSTYLE
+  1
+TABLEFORMAT_BEGIN
+ 90
+        5
+170
+     1
+ 91
+        0
+ 92
+        0
+ 62
+   257
+ 93
+        1
+300
+CONTENTFORMAT
+  1
+CONTENTFORMAT_BEGIN
+ 90
+        0
+ 91
+        0
+ 92
+      512
+ 93
+        0
+300
+
+ 40
+0.0
+140
+1.0
+ 94
+        5
+ 62
+     0
+340
+11
+144
+0.18
+309
+CONTENTFORMAT_END
+171
+     1
+301
+MARGIN
+  1
+CELLMARGIN_BEGIN
+ 40
+0.06
+ 40
+0.06
+ 40
+0.06
+ 40
+0.06
+ 40
+0.18
+ 40
+0.18
+309
+CELLMARGIN_END
+ 94
+        6
+ 95
+        1
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+        2
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+        4
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+        8
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+       16
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+       32
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+309
+TABLEFORMAT_END
+  1
+CELLSTYLE_BEGIN
+ 90
+        2
+ 91
+        1
+300
+_HEADER
+309
+CELLSTYLE_END
+300
+CELLSTYLE
+  1
+TABLEFORMAT_BEGIN
+ 90
+        5
+170
+     1
+ 91
+        0
+ 92
+        0
+ 62
+   257
+ 93
+        1
+300
+CONTENTFORMAT
+  1
+CONTENTFORMAT_BEGIN
+ 90
+        0
+ 91
+        0
+ 92
+      512
+ 93
+        0
+300
+
+ 40
+0.0
+140
+1.0
+ 94
+        2
+ 62
+     0
+340
+11
+144
+0.18
+309
+CONTENTFORMAT_END
+171
+     1
+301
+MARGIN
+  1
+CELLMARGIN_BEGIN
+ 40
+0.06
+ 40
+0.06
+ 40
+0.06
+ 40
+0.06
+ 40
+0.18
+ 40
+0.18
+309
+CELLMARGIN_END
+ 94
+        6
+ 95
+        1
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+        2
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+        4
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+        8
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+       16
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+ 95
+       32
+302
+GRIDFORMAT
+  1
+GRIDFORMAT_BEGIN
+ 90
+        0
+ 91
+        1
+ 62
+     0
+ 92
+       -2
+340
+0
+ 93
+        0
+ 40
+0.045
+309
+GRIDFORMAT_END
+309
+TABLEFORMAT_END
+  1
+CELLSTYLE_BEGIN
+ 90
+        3
+ 91
+        2
+300
+_DATA
+309
+CELLSTYLE_END
+  0
+ENDSEC
+  0
+SECTION
+  2
+ACDSDATA
+ 70
+     2
+ 71
+     8
+  0
+ACDSSCHEMA
+ 90
+        0
+  1
+AcDb_Thumbnail_Schema
+  2
+AcDbDs::ID
+280
+    10
+ 91
+        8
+  2
+Thumbnail_Data
+280
+    15
+ 91
+        0
+101
+ACDSRECORD
+ 95
+        0
+ 90
+        1
+  2
+AcDbDs::TreatedAsObjectData
+280
+     1
+291
+     1
+101
+ACDSRECORD
+ 95
+        0
+ 90
+        2
+  2
+AcDbDs::Legacy
+280
+     1
+291
+     1
+101
+ACDSRECORD
+  1
+AcDbDs::ID
+ 90
+        3
+  2
+AcDs:Indexable
+280
+     1
+291
+     1
+101
+ACDSRECORD
+  1
+AcDbDs::ID
+ 90
+        4
+  2
+AcDbDs::HandleAttribute
+280
+     7
+282
+     1
+  0
+ACDSSCHEMA
+ 90
+        1
+  1
+AcDbDs::TreatedAsObjectDataSchema
+  2
+AcDbDs::TreatedAsObjectData
+280
+     1
+ 91
+        0
+  0
+ACDSSCHEMA
+ 90
+        2
+  1
+AcDbDs::LegacySchema
+  2
+AcDbDs::Legacy
+280
+     1
+ 91
+        0
+  0
+ACDSSCHEMA
+ 90
+        3
+  1
+AcDbDs::IndexedPropertySchema
+  2
+AcDs:Indexable
+280
+     1
+ 91
+        0
+  0
+ACDSSCHEMA
+ 90
+        4
+  1
+AcDbDs::HandleAttributeSchema
+  2
+AcDbDs::HandleAttribute
+280
+     7
+ 91
+        1
+284
+     1
+  0
+ACDSRECORD
+ 90
+        0
+  2
+AcDbDs::ID
+280
+    10
+320
+22
+  2
+Thumbnail_Data
+280
+    15
+ 94
+     1049
+310
+89504E470D0A1A0A0000000D49484452000001000000009C0803000000A77F85D800000300504C5445212830FFFFFF2128300000000000000000000000000000000000000000000000000000330000660000990000CC0000FF0033000033330033660033990033CC0033FF0066000066330066660066990066CC0066FF0099
+310
+000099330099660099990099CC0099FF00CC0000CC3300CC6600CC9900CCCC00CCFF00FF0000FF3300FF6600FF9900FFCC00FFFF3300003300333300663300993300CC3300FF3333003333333333663333993333CC3333FF3366003366333366663366993366CC3366FF3399003399333399663399993399CC3399FF33CC00
+310
+33CC3333CC6633CC9933CCCC33CCFF33FF0033FF3333FF6633FF9933FFCC33FFFF6600006600336600666600996600CC6600FF6633006633336633666633996633CC6633FF6666006666336666666666996666CC6666FF6699006699336699666699996699CC6699FF66CC0066CC3366CC6666CC9966CCCC66CCFF66FF0066
+310
+FF3366FF6666FF9966FFCC66FFFF9900009900339900669900999900CC9900FF9933009933339933669933999933CC9933FF9966009966339966669966999966CC9966FF9999009999339999669999999999CC9999FF99CC0099CC3399CC6699CC9999CCCC99CCFF99FF0099FF3399FF6699FF9999FFCC99FFFFCC0000CC00
+310
+33CC0066CC0099CC00CCCC00FFCC3300CC3333CC3366CC3399CC33CCCC33FFCC6600CC6633CC6666CC6699CC66CCCC66FFCC9900CC9933CC9966CC9999CC99CCCC99FFCCCC00CCCC33CCCC66CCCC99CCCCCCCCCCFFCCFF00CCFF33CCFF66CCFF99CCFFCCCCFFFFFF0000FF0033FF0066FF0099FF00CCFF00FFFF3300FF3333
+310
+FF3366FF3399FF33CCFF33FFFF6600FF6633FF6666FF6699FF66CCFF66FFFF9900FF9933FF9966FF9999FF99CCFF99FFFFCC00FFCC33FFCC66FFCC99FFCCCCFFCCFFFFFF00FFFF33FFFF66FFFF99FFFFCCFFFFFF0000000D0D0D1A1A1A2828283535354343435050505D5D5D6B6B6B787878868686939393A1A1A1AEAEAEBB
+310
+BBBBC9C9C9D6D6D6E4E4E4F1F1F1FFFFFF0000000000000000000000000000000000000000000000000000000000002E4550F1000000D44944415478DAEDDB316E80401004C1FDFF7F27870081104224903055911DD2B77B7672330000000000000000AF4BAA3F7EFDFC147FFDF643EBD1EFBFD41E7D65805C2FBD740E7E5D
+310
+81DCFFBD4BEDD1970478FE57E7E70532E501260208E012300202D8012320801D10C00E0860078C800076C0080820804BC0080860078C800002B8048C800076C00808600704B00302D8012320801D30020208E01248F3083CBC2BF87980943CA14CEDD1DF1648D9EBD9547FFD294052F9723AB5477F1448CA1FCD0F00000000
+310
+00000000000000000000F0AD05877DA49DADE774D80000000049454E44AE426082
+  0
+ENDSEC
+  0
+EOF

--- a/tests/test_01_dxf_entities/test_135_geo_data.py
+++ b/tests/test_01_dxf_entities/test_135_geo_data.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018 Manfred Moitzi
 # License: MIT License
 import math
+import os
 
 import pytest
 
@@ -356,10 +357,15 @@ DUMMY_OTT
 """
 
 
-def test_interpreting_geodata():
+@pytest.fixture
+def georeferenced_test_file_path() -> str:
+    return os.path.join(os.path.dirname(__file__), 'houses_of_parliament_georeferenced.dxf')
+
+
+def test_interpreting_geodata(georeferenced_test_file_path):
     # it is unclear how to create a georeferenced file from scratch. Copying every GeoData attribute and document
     # header value across was not enough for AutoCAD to correctly interpret the coordinates
-    doc = ezdxf.readfile('houses_of_parliament_georeferenced.dxf')
+    doc = ezdxf.readfile(georeferenced_test_file_path)
     geodata = doc.modelspace().get_geodata()
 
     assert geodata.decoded_units() == ('in', 'in')  # inches

--- a/tests/test_01_dxf_entities/test_135_geo_data.py
+++ b/tests/test_01_dxf_entities/test_135_geo_data.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2018 Manfred Moitzi
 # License: MIT License
+import math
+
 import pytest
+
 import ezdxf
-from ezdxf.entities.geodata import GeoData
+from ezdxf.entities.geodata import GeoData, InvalidGeoDataException
 from ezdxf.lldxf.tagwriter import TagCollector, basic_tags_from_text
+from ezdxf.math import Vector, Matrix44
 
 GEODATA = """0
 GEODATA
@@ -350,3 +354,49 @@ DUMMY_OTT
 96
 0
 """
+
+
+def test_interpreting_geodata():
+    # it is unclear how to create a georeferenced file from scratch. Copying every GeoData attribute and document
+    # header value across was not enough for AutoCAD to correctly interpret the coordinates
+    doc = ezdxf.readfile('houses_of_parliament_georeferenced.dxf')
+    geodata = doc.modelspace().get_geodata()
+
+    assert geodata.decoded_units() == ('in', 'in')  # inches
+
+    coordinate_system_definition = geodata.coordinate_system_definition
+    geodata.coordinate_system_definition = ''
+    with pytest.raises(InvalidGeoDataException):
+        geodata.get_crs()
+    geodata.coordinate_system_definition = coordinate_system_definition
+
+    assert geodata.get_crs() == (27700, True)
+
+    # the outline of the Houses of Parliament in London, WCS coordinates are meaningless, but the cad file is
+    # georeferenced as epsg:27700
+    expected_geo_points = [
+        (530207.5677217417, 179366.7895852687), (530304.7243275082, 179354.44795162012),
+        (530337.0722795193, 179620.5081263125), (530285.502052045, 179626.77810356658),
+        (530288.2604343889, 179649.46565077276), (530260.6778594478, 179652.81917713786),
+        (530256.9625486559, 179629.5648430319), (530266.9241695277, 179627.97328950214),
+        (530259.8925073204, 179577.1375901363), (530179.7793595218, 179598.3848030573),
+        (530174.8000936891, 179519.37903558338), (530189.905505017, 179515.41460442453),
+        (530184.6203071928, 179495.27676273056), (530217.9628916974, 179486.52596620753),
+        (530223.1861964873, 179485.42147930583), (530207.5677217417, 179366.7895852687)
+    ]
+    expected_transformation = Matrix44(
+        (0.02154042164237322, -0.013459949311523403, 0.0, 0.0),
+        (0.013459949311523403, 0.02154042164237322, 0.0, 0.0),
+        (0.0, 0.0, 1.0, 0.0),
+        (529635.6280343985, 179575.4070305015, 0.0, 1.0)
+    )
+
+    transformation, epsg = geodata.get_crs_transformation()
+    assert epsg == 27700
+    assert all(math.isclose(x1, x2) for x1, x2 in zip(transformation, expected_transformation))
+
+    entity = list(doc.modelspace().query('LWPOLYLINE'))[0]
+    georeferenced_entity = entity.transform(transformation)
+    transformed_points = georeferenced_entity.get_points(format='xy')
+    assert len(transformed_points) == len(expected_geo_points)
+    assert all(Vector(x1).isclose(Vector(x2)) for x1, x2 in zip(transformed_points, expected_geo_points))


### PR DESCRIPTION
after posting #214 I made a breakthrough in interpreting GeoData created by georeferencing in AutoCAD.
I realised that `source_vertices` and `target_vertices` are completely useless and have nothing to do with the particular CAD file in question, but rather they define the CRS transformation between the CRS of the GeoData and WGS84 (The sort of thing which can already be done by a library like `pyproj`).

I have added support for parsing the epsg number of the CRS from GeoData specified in the way that AutoCAD does it (as xml using what appears to be a custom format), and obtaining the transformation which transforms from WCS into that CRS.

There are a lot of checks to make sure that the GeoData is very similar to the ones that I have tested on, although some of those checks could probably be relaxed. The problem is I don't know how to create dxf files for those scenarios in AutoCAD.

I tried creating a test dxf document using ezdxf like the other unit tests do, however although I was able to create a dxf document which ezdxf could correctly extract the GeoData from, AutoCAD did not interpret this document correctly when I exported it, so I must have been missing some important values somewhere. To get around this I just included the dxf file I was using directly.

The file is a single polyline for the outline of the Houses of Parliament in London, with the document units in inches and georeferenced as [epsg:27700](https://epsg.io/27700)
![image (12)](https://user-images.githubusercontent.com/4923501/91073264-b3f2ab80-e632-11ea-9caa-9f125ac74e06.png)
