### PR TITLE
Qsave improvements

### DIFF
--- a/src/ezdxf/addons/drawing/matplotlib.py
+++ b/src/ezdxf/addons/drawing/matplotlib.py
@@ -223,8 +223,7 @@ def qsave(layout: 'Layout', filename: str, *,
             ctx.current_layout.set_colors(bg, fg)
         out = MatplotlibBackend(ax)
         Frontend(ctx, out).draw_layout(layout, finalize=True)
-        fig.savefig(filename, dpi=dpi,
-                    facecolor=ax.get_facecolor(), transparent=True)
+        fig.savefig(filename, dpi=dpi, facecolor=ax.get_facecolor())
         plt.close(fig)
     finally:
         matplotlib.use(old_backend)

--- a/src/ezdxf/addons/drawing/matplotlib.py
+++ b/src/ezdxf/addons/drawing/matplotlib.py
@@ -226,7 +226,12 @@ def qsave(layout: 'Layout', filename: str, *,
             ctx.current_layout.set_colors(bg, fg)
         out = MatplotlibBackend(ax)
         Frontend(ctx, out).draw_layout(layout, finalize=True)
-        fig.savefig(filename, dpi=dpi, facecolor=ax.get_facecolor())
+        # transparent=True sets the axes color to fully transparent
+        # facecolor sets the figure color
+        # (semi-)transparent axes colors do not produce transparent outputs
+        # but (semi-)transparent figure colors do.
+        fig.savefig(filename, dpi=dpi,
+                    facecolor=ax.get_facecolor(), transparent=True)
         plt.close(fig)
     finally:
         matplotlib.use(old_backend)

--- a/src/ezdxf/addons/drawing/matplotlib.py
+++ b/src/ezdxf/addons/drawing/matplotlib.py
@@ -214,16 +214,18 @@ def qsave(layout: 'Layout', filename: str, *,
     # other than the main thread
     old_backend = matplotlib.get_backend()
     matplotlib.use('Agg')
-    fig: plt.Figure = plt.figure()
-    ax: plt.Axes = fig.add_axes((0, 0, 1, 1))
-    ctx = RenderContext(layout.doc)
-    ctx.set_current_layout(layout)
-    if bg is not None:
-        ctx.current_layout.set_colors(bg, fg)
-    out = MatplotlibBackend(ax)
-    Frontend(ctx, out).draw_layout(layout, finalize=True)
-    fig.savefig(filename, dpi=dpi,
-                facecolor=ax.get_facecolor(), transparent=True)
-    plt.close(fig)
-    matplotlib.use(old_backend)
+    try:
+        fig: plt.Figure = plt.figure()
+        ax: plt.Axes = fig.add_axes((0, 0, 1, 1))
+        ctx = RenderContext(layout.doc)
+        ctx.set_current_layout(layout)
+        if bg is not None:
+            ctx.current_layout.set_colors(bg, fg)
+        out = MatplotlibBackend(ax)
+        Frontend(ctx, out).draw_layout(layout, finalize=True)
+        fig.savefig(filename, dpi=dpi,
+                    facecolor=ax.get_facecolor(), transparent=True)
+        plt.close(fig)
+    finally:
+        matplotlib.use(old_backend)
 

--- a/src/ezdxf/addons/drawing/matplotlib.py
+++ b/src/ezdxf/addons/drawing/matplotlib.py
@@ -189,6 +189,7 @@ def qsave(layout: 'Layout', filename: str, *,
           bg: Optional[Color] = None,
           fg: Optional[Color] = None,
           dpi: int = 300,
+          matplotlib_backend: str = 'agg',
           ) -> None:
     """ Quick and simplified render export by matplotlib.
 
@@ -203,6 +204,8 @@ def qsave(layout: 'Layout', filename: str, *,
             has already a variable color value (black/white) and ezdxf let you
             override this ACI color.
         dpi: image resolution (dots per inches).
+        matplotlib_backend: the rendering backend to use (agg, cairo, svg etc)
+          (see documentation for matplotlib.use() for a complete list of backends)
 
     .. versionadded:: 0.14
 
@@ -213,7 +216,7 @@ def qsave(layout: 'Layout', filename: str, *,
     # set the backend to prevent warnings about GUIs being opened from a thread
     # other than the main thread
     old_backend = matplotlib.get_backend()
-    matplotlib.use('Agg')
+    matplotlib.use(matplotlib_backend)
     try:
         fig: plt.Figure = plt.figure()
         ax: plt.Axes = fig.add_axes((0, 0, 1, 1))


### PR DESCRIPTION
a few small things changed with the quick save utility:
- I am not sure if there would ever be a use for any rect other than (0, 0, 1, 1) since the image could just be loaded and manipulated afterwards if the user truly only wanted part of the image to be filled with the CAD drawing. If you think it would be useful then I can revert that change
- `transparent=True` sets the axis color to fully transparent and `facecolor=...` sets the figure color. If the output format doesn't support transparency then the output will just become opaque so I don't think there is a need to expose a parameter for `transparent`
    - if neither `transparent` or `facecolor` is used then the output will be opaque even if the cad/axis background color is semi-transparent  
    - if only transparent is used then the background is fully transparent
    - if only facecolor is used then the alpha will be twice what is should be (because both the figure and axes have the same alpha and are overlaid on top of each other)
    - so both facecolor and transparent need to be set to get the correct alpha value in the output image
- by default, the matplotlib backend will probably be something like `qt5Agg` or `tkAgg` which have support for calling `plt.show()` (opening a GUI window), however a warning will be raised if a figure is created on any thread other than the main thread. Since `plt.show()` will never be called for this function, it is a good idea to use a non-interactive backend which can only write to files (and restore the backend afterwards)