### PR TITLE
separated out _get_text_path for easier optimization

### DIFF
--- a/src/ezdxf/addons/drawing/pyqt.py
+++ b/src/ezdxf/addons/drawing/pyqt.py
@@ -153,8 +153,7 @@ class PyQtBackend(Backend):
         scale = cap_height / self._font_measurements.cap_height
         transform = Matrix44.scale(scale, -scale, 0) @ transform
 
-        path = qg.QPainterPath()
-        path.addText(0, 0, self._font, text)
+        path = _get_text_path(self._font, text)
         path = _matrix_to_qtransform(transform).map(path)
         item = self.scene.addPath(path, self._no_line,
                                   self._get_color(properties.color))
@@ -203,10 +202,14 @@ def _matrix_to_qtransform(matrix: Matrix44) -> qg.QTransform:
     return qg.QTransform(*matrix.get_2d_transformation())
 
 
-def _get_text_rect(font: qg.QFont, text: str) -> qc.QRectF:
+def _get_text_path(font: qg.QFont, text: str) -> qc.QRectF:
     path = qg.QPainterPath()
     path.addText(0, 0, font, text)
-    return path.boundingRect()
+    return path
+
+
+def _get_text_rect(font: qg.QFont, text: str) -> qc.QRectF:
+    return _get_text_path(font, text).boundingRect()
 
 
 def _get_font_measurements(font: qg.QFont) -> FontMeasurements:


### PR DESCRIPTION
I'm trying to improve draw speeds with the pyqt backend. Text seems to be one of the bottlenecks. I've tripled the performance of  `draw_text_entity_2d()`  by using the built-in python LRU cache on text path creation. (tested with my production cad files) 

This pull request makes it easier for me to patch in my caching system. 

I figured you would probably not want to add the LRU cache to master at this point. In case you are curious about my implementation, I currently have this in cad_viewer.py:
```
@lru_cache(maxsize=2048)
def _get_text_rect(font: qg.QFont, text: str) -> qc.QRectF:

    split_text = text.split()
    if len(split_text) == 1:  # No spaces
        return _get_text_path(font, text).boundingRect()

    width = 0
    height = 0
    space_width = _get_text_path(font, " ").boundingRect().width()
    for word in split_text:
        new_size = _get_text_path(font, word).boundingRect()
        width += new_size.width() + space_width
        height = max(height, new_size.height())
    width -= space_width
    return qc.QRectF(0, 0, width, height)


ezdxf.addons.drawing.pyqt._get_text_rect = _get_text_rect


@lru_cache(maxsize=2048)
def _get_text_path(font: qg.QFont, text: str) -> qc.QRectF:
    path = qg.QPainterPath()
    path.addText(0, 0, font, text)
    return path


ezdxf.addons.drawing.pyqt._get_text_path = _get_text_path
```