### PR TITLE
Text caching

### DIFF
--- a/src/ezdxf/addons/drawing/text.py
+++ b/src/ezdxf/addons/drawing/text.py
@@ -63,6 +63,13 @@ class FontMeasurements:
         self.x_top = x_top
         self.bottom = bottom
 
+    def __eq__(self, other):
+        return (isinstance(other, FontMeasurements) and
+                self.baseline == other.baseline and
+                self.cap_top == other.cap_top and
+                self.x_top == other.x_top and
+                self.bottom == other.bottom)
+
     def scale_from_baseline(self, desired_cap_height: float) -> "FontMeasurements":
         scale = desired_cap_height / self.cap_height
         assert math.isclose(self.baseline, 0.0)


### PR DESCRIPTION
improving on  #234, this change introduces the capability for the Qt and matplotlib backends to cache paths for text.
The improvements aren't as dramatic as the 3x that @DGriffin91 obtained but there is a significant improvement anyway.

I also encountered a subtle bug because I was benchmarking with random strings. It turns out that even if `TextPath` is passed `usetex=False`, it will attempt to identify math text in between `$` characters like it would in tex mode. To avoid this, the matplotlib backend has to escape any `$` characters to `\$`. This change is included in this pull request.

reusing the matplotlib backend for different axes would be tricky since there is no `start_drawing()` to accompany `finalize()` and `finalize()` of the matplotlib backend alters some global state (`plt.rcParams`) so some redesigning might be required to do that. However the Qt backend seems Ok to be reused. I added a function `set_scene()` to reuse the backend for drawing to multiple scenes, allowing the cache to be reused between them.

tested with 1000 random strings: the matplotlib backend improved from 16 seconds without caching to 13 seconds.
tested with 10,000 random strings: the pyqt backend:
- first draw: 9 seconds without caching to 6 seconds (most likely because the paths don't have to be calculated twice, once for getting the rect for laying out the text, then again for drawing)
- redraws: 9 seconds without caching to 2.5 seconds

The following script was used to create a dxf file used for benchmarking (not included in the repo because I didn't know where to put it or whether you would want it)
```python
import argparse
import random
import string

import ezdxf


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument('--num_strings', default=10000)
    parser.add_argument('--width', default=1000)
    parser.add_argument('--height', default=1000)
    args = parser.parse_args()

    letters = string.ascii_letters + string.digits + string.punctuation

    random.seed(0)

    doc = ezdxf.new()
    layout = doc.modelspace()
    for i in range(args.num_strings):
        s = ''.join(random.choices(letters, k=random.randint(1, 100)))

        dxf = {'insert': (random.randint(0, args.width), random.randint(0, args.height)),
               'rotation': random.uniform(0, 360),
               'height': random.uniform(1, 20), 'color': random.randint(0, 256)}
        layout.add_text(s, dxf)

    doc.saveas('/tmp/doc.dxf')


if __name__ == '__main__':
    main()
```
![image](https://user-images.githubusercontent.com/4923501/93668818-13ec3e80-fa87-11ea-9bb4-2029a078d944.png)

