### PR TITLE
improved performance of ezdxf linestyle rendering

### DIFF
--- a/src/ezdxf/addons/drawing/matplotlib.py
+++ b/src/ezdxf/addons/drawing/matplotlib.py
@@ -7,6 +7,7 @@ from enum import Enum
 import abc
 
 import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
 from matplotlib.font_manager import FontProperties
 from matplotlib.lines import Line2D
 from matplotlib.patches import Circle, PathPatch
@@ -397,14 +398,13 @@ class EzdxfLineRenderer(AbstractLineRenderer):
                 ))
         else:
             renderer = EzdxfLineTypeRenderer(pattern)
-            for s, e in renderer.line_segment(start, end):
-                ax.add_line(
-                    Line2D(
-                        (s.x, e.x), (s.y, e.y),
-                        linewidth=lineweight,
-                        color=color,
-                        zorder=z,
-                    ))
+            lines = LineCollection(
+                [((s.x, s.y), (e.x, e.y))
+                 for s, e in renderer.line_segment(start, end)],
+                linewidths=lineweight, color=color, zorder=z
+            )
+            lines.set_capstyle('butt')
+            ax.add_collection(lines)
 
     def draw_path(self, ax: plt.Axes, path, properties: Properties, z: float):
         pattern = self.pattern(properties)
@@ -422,15 +422,14 @@ class EzdxfLineRenderer(AbstractLineRenderer):
             ax.add_patch(patch)
         else:
             renderer = EzdxfLineTypeRenderer(pattern)
-            for s, e in renderer.line_segments(
-                    path.flattening(self._max_distance, segments=16)):
-                ax.add_line(
-                    Line2D(
-                        (s.x, e.x), (s.y, e.y),
-                        linewidth=lineweight,
-                        color=color,
-                        zorder=z,
-                    ))
+            segments = renderer.line_segments(path.flattening(
+                self._max_distance, segments=16))
+            lines = LineCollection(
+                [((s.x, s.y), (e.x, e.y)) for s, e in segments],
+                linewidths=lineweight, color=color, zorder=z
+            )
+            lines.set_capstyle('butt')
+            ax.add_collection(lines)
 
     def create_pattern(self, properties: Properties, scale: float):
         """ Returns simplified linetype tuple: on_off_sequence """


### PR DESCRIPTION
When writing my last pull request I noticed that `Line2D` was being used to draw the line segments of different linestyles. Matplotlib provides better tools for drawing many identical lines: `LineCollection`. This pull request makes use of this.

Using the script below which generates 1000 random lines of random line types, I benchmarked the internal line rendering against the `Line2D` and `LineCollection` based `ezdxf` renderers:

- internal: 0.7 seconds
- `Line2D`: 13 seconds
- `LineCollection`: 1.7 seconds

I think that a `Path` with `MOVETO` and `LINETO` commands could also work but I haven't tested that so I don't know if it would be faster than linecollection, but I think this speed is acceptable.

The output appears slightly different when using a LineCollection. I think this is due to the capstyle being used. I think `'butt'` makes the most sense: <https://matplotlib.org/3.1.0/gallery/lines_bars_and_markers/joinstyle.html#cap-styles>

internal:
![out_internal](https://user-images.githubusercontent.com/4923501/93670175-35eabe80-fa91-11ea-84e5-764518459a97.png)
Line2D based ezdxf:
![out_old](https://user-images.githubusercontent.com/4923501/93670177-3d11cc80-fa91-11ea-840d-925b42728191.png)
LineCollection based ezdxf:
![out](https://user-images.githubusercontent.com/4923501/93670180-426f1700-fa91-11ea-9341-57aa8adf7110.png)


```python
import argparse
import random

import ezdxf
from ezdxf.tools import standards


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument('--num_lines', default=1000)
    parser.add_argument('--width', default=10)
    parser.add_argument('--height', default=10)
    args = parser.parse_args()

    random.seed(0)

    doc = ezdxf.new('R2000', setup=True)
    layout = doc.modelspace()
    linetypes = standards.linetypes()
    for i in range(args.num_lines):
        ltype = random.choice(linetypes)
        pos = (random.randint(0, args.width), random.randint(0, args.height))
        l = 10
        pos2 = pos[0] + random.randint(-l, l), pos[1] + random.randint(-l, l)
        layout.add_line(pos, pos2, dxfattribs={'linetype': ltype[0]})

    doc.saveas('/tmp/doc.dxf')


if __name__ == '__main__':
    main()
```
