### PR TITLE
added support for fonts with baselines other than y=0

### DIFF
--- a/src/ezdxf/addons/drawing/matplotlib.py
+++ b/src/ezdxf/addons/drawing/matplotlib.py
@@ -244,11 +244,12 @@ class TextRenderer:
         upper_x = self.get_text_path('X').vertices[:, 1].tolist()
         lower_x = self.get_text_path('x').vertices[:, 1].tolist()
         lower_p = self.get_text_path('p').vertices[:, 1].tolist()
+        baseline = min(lower_x)
         return FontMeasurements(
-            baseline=min(lower_x),
-            cap_top=max(upper_x),
-            x_top=max(lower_x),
-            bottom=min(lower_p)
+            baseline=baseline,
+            cap_height=max(upper_x) - baseline,
+            x_height=max(lower_x) - baseline,
+            descender_height=baseline - min(lower_p)
         )
 
     def get_text_path(self, text: str) -> TextPath:

--- a/src/ezdxf/addons/drawing/pyqt.py
+++ b/src/ezdxf/addons/drawing/pyqt.py
@@ -250,11 +250,12 @@ class TextRenderer:
         upper_x = self.get_text_rect('X')
         lower_x = self.get_text_rect('x')
         lower_p = self.get_text_rect('p')
+        baseline = lower_x.bottom()
         return FontMeasurements(
-            baseline=lower_x.bottom(),
-            cap_top=upper_x.top(),
-            x_top=lower_x.top(),
-            bottom=lower_p.bottom(),
+            baseline=baseline,
+            cap_height=upper_x.top() - baseline,
+            x_height=lower_x.top() - baseline,
+            descender_height=baseline - lower_p.bottom(),
         )
 
     def get_text_path(self, text: str) -> qg.QPainterPath:

--- a/src/ezdxf/addons/drawing/text.py
+++ b/src/ezdxf/addons/drawing/text.py
@@ -57,40 +57,39 @@ assert len(DXF_MTEXT_ALIGNMENT_TO_ALIGNMENT) == len(DXFConstants.MTEXT_ALIGN_FLA
 
 
 class FontMeasurements:
-    def __init__(self, baseline: float, cap_top: float, x_top: float, bottom: float):
+    def __init__(self, baseline: float, cap_height: float, x_height: float, descender_height: float):
         self.baseline = baseline
-        self.cap_top = cap_top
-        self.x_top = x_top
-        self.bottom = bottom
+        self.cap_height = cap_height
+        self.x_height = x_height
+        self.descender_height = descender_height
 
     def __eq__(self, other):
         return (isinstance(other, FontMeasurements) and
                 self.baseline == other.baseline and
-                self.cap_top == other.cap_top and
-                self.x_top == other.x_top and
-                self.bottom == other.bottom)
+                self.cap_height == other.cap_height and
+                self.x_height == other.x_height and
+                self.descender_height == other.descender_height)
 
     def scale_from_baseline(self, desired_cap_height: float) -> "FontMeasurements":
         scale = desired_cap_height / self.cap_height
-        assert math.isclose(self.baseline, 0.0)
         return FontMeasurements(
             baseline=self.baseline,
-            cap_top=desired_cap_height,
-            x_top=self.x_height * scale,
-            bottom=self.bottom * scale,
+            cap_height=desired_cap_height,
+            x_height=self.x_height * scale,
+            descender_height=self.descender_height * scale,
         )
 
     @property
-    def cap_height(self) -> float:
-        return abs(self.cap_top - self.baseline)
+    def cap_top(self) -> float:
+        return self.baseline + self.cap_height
 
     @property
-    def x_height(self) -> float:
-        return abs(self.x_top - self.baseline)
+    def x_top(self) -> float:
+        return self.baseline + self.x_height
 
     @property
-    def descender_height(self) -> float:
-        return abs(self.baseline - self.bottom)
+    def bottom(self) -> float:
+        return self.baseline - self.descender_height
 
 
 def _get_rotation(text: AnyText) -> Matrix44:
@@ -211,7 +210,6 @@ def _get_extra_transform(text: AnyText) -> Matrix44:
 
 def _apply_alignment(alignment: Alignment,
                      line_widths: List[float],
-                     cap_height: float,
                      line_spacing: float,
                      box_width: Optional[float],
                      font_measurements: FontMeasurements) -> Tuple[Tuple[float, float], List[float], List[float]]:
@@ -219,7 +217,9 @@ def _apply_alignment(alignment: Alignment,
         return (0, 0), [], []
 
     halign, valign = alignment
-    line_ys = [-(cap_height + i * line_spacing) for i in range(len(line_widths))]
+    line_ys = [-font_measurements.baseline -
+               (font_measurements.cap_height + i * line_spacing)
+               for i in range(len(line_widths))]
 
     if box_width is None:
         box_width = max(line_widths)
@@ -278,7 +278,7 @@ def simplified_text_chunks(text: AnyText, out: Backend,
     line_widths = [out.get_text_line_width(line, cap_height, font=font) for line in lines]
     font_measurements = out.get_font_measurements(cap_height, font=font)
     anchor, line_xs, line_ys = \
-        _apply_alignment(alignment, line_widths, cap_height, line_spacing, box_width, font_measurements)
+        _apply_alignment(alignment, line_widths, line_spacing, box_width, font_measurements)
     rotation = _get_rotation(text)
     extra_transform = _get_extra_transform(text)
     insert = _get_wcs_insert(text)

--- a/tests/test_08_addons/test_811_drawing_frontend.py
+++ b/tests/test_08_addons/test_811_drawing_frontend.py
@@ -39,8 +39,8 @@ class BasicBackend(Backend):
 
     def get_font_measurements(self, cap_height: float,
                               font=None) -> FontMeasurements:
-        return FontMeasurements(baseline=0.0, cap_top=1.0, x_top=0.5,
-                                bottom=-0.2)
+        return FontMeasurements(baseline=0.0, cap_height=1.0, x_height=0.5,
+                                descender_height=0.2)
 
     def set_background(self, color: str) -> None:
         self.collector.append(('bgcolor', color))


### PR DESCRIPTION
this pull request fixes rendering using a font which has a baseline other than y=0. This fixes #241.

The new approach is also slightly more efficient because the heights (i.e. distances from the baseline) are stored rather than the absolute y values. The text alignment only ever uses the heights anyway so it makes sense to store those rather than the y values.

in a non very rigorous test I rendered the `examples_dxf/text.dxf` before and after this change.
- if the font has baseline = 0 then the outputs are exactly identical (as expected)
- if the baseline is != 0 then the results are different. I used the `Gayathri` font family (because it was the first one I picked at random with a non-zero baseline) which has a baseline at -0.0117 and there were some very slight differences (tested using the difference layer mode in gimp). Obviously the difference is more pronounced the further the baseline is from 0

difference between the images before and after this fix (with contrast boosted to make extremely subtle differences visible)
![image](https://user-images.githubusercontent.com/4923501/95122713-d525dc00-0748-11eb-99aa-14ded05e7dd5.png)
