### PR TITLE
small fix to use correct data roles

### DIFF
--- a/src/ezdxf/addons/drawing/pyqt.py
+++ b/src/ezdxf/addons/drawing/pyqt.py
@@ -44,8 +44,8 @@ class _Point(qw.QAbstractGraphicsShapeItem):
 
 
 # The key used to store the dxf entity corresponding to each graphics element
-CorrespondingDXFEntity = 0
-CorrespondingDXFParentStack = 1
+CorrespondingDXFEntity = qc.Qt.UserRole + 0
+CorrespondingDXFParentStack = qc.Qt.UserRole + 1
 
 PYQT_DEFAULT_PARAMS = {
     # For my taste without scaling the default line width looks to thin:


### PR DESCRIPTION
a minor fix. I just realised that data roles less than `0x0100` (`Qt::UserRole`) shouldn't be used for application specific purposes:
https://doc.qt.io/qt-5/qt.html#ItemDataRole-enum
