### PR TITLE
replace new column escape codes

### DIFF
--- a/src/ezdxf/tools/text.py
+++ b/src/ezdxf/tools/text.py
@@ -193,7 +193,7 @@ def plain_text(text: str) -> str:
     return "".join(chars)
 
 
-ONE_CHAR_COMMANDS = "PLlOoKkX"
+ONE_CHAR_COMMANDS = "PNLlOoKkX"
 
 
 ##################################################
@@ -205,6 +205,7 @@ ONE_CHAR_COMMANDS = "PLlOoKkX"
 # \K	Start strike-through
 # \k	Stop strike-through
 # \P	New paragraph (new line)
+# \N	New column
 # \pxi	Control codes for bullets, numbered paragraphs and columns
 # \X	Paragraph wrap on the dimension line (only in dimensions)
 # \Q	Slanting (oblique) text by angle - e.g. \Q30;
@@ -268,7 +269,10 @@ def plain_mtext(text: str, split=False) -> Union[List[str], str]:
             elif char in ONE_CHAR_COMMANDS:
                 if char == 'P':  # new line
                     chars.append('\n')
-                    # discard other commands
+                elif char == 'N':  # new column
+                    chars.append(' ')  # until columns are supported, better to at least remove the escape character
+                else:
+                    pass  # discard other commands
             else:  # more character commands are terminated by ';'
                 stacking = char == 'S'  # stacking command surrounds user data
                 first_char = char


### PR DESCRIPTION
Since support for columns is probably not coming soon (I don't have a particular need for them) it is better to at least replace `\N` with something sensible for the time being.

![image](https://user-images.githubusercontent.com/4923501/106454055-1d98a080-6482-11eb-9de3-fff8d888c972.png)

![image](https://user-images.githubusercontent.com/4923501/106454043-1a9db000-6482-11eb-833e-ec0646aa3959.png)
