### PR TITLE
made Qt brushes cosmetic

### DIFF
--- a/src/ezdxf/addons/drawing/pyqt.py
+++ b/src/ezdxf/addons/drawing/pyqt.py
@@ -295,7 +295,9 @@ class _CosmeticPolygon(qw.QGraphicsPolygonItem):
 def _set_cosmetic_brush(item: qw.QGraphicsItem, painter: qg.QPainter) -> None:
     """ like a cosmetic pen, this sets the brush pattern to appear the same independent of the view """
     brush = item.brush()
-    brush.setTransform(painter.transform().inverted()[0])
+    # scale by -1 in y because the view is always mirrored in y and undoing the view transformation entirely would make
+    # the hatch mirrored w.r.t the view
+    brush.setTransform(painter.transform().inverted()[0].scale(1, -1))
     item.setBrush(brush)
 
 

--- a/src/ezdxf/addons/drawing/pyqt.py
+++ b/src/ezdxf/addons/drawing/pyqt.py
@@ -200,11 +200,10 @@ class PyQtBackend(Backend):
             _extend_qt_path(qt_path, path.counter_clockwise())
         for path in holes:
             _extend_qt_path(qt_path, path.clockwise())
-        item = self._scene.addPath(
-            qt_path,
-            self._get_pen(properties),
-            self._get_brush(properties),
-        )
+        item = _CosmeticPath(qt_path)
+        item.setPen(self._get_pen(properties))
+        item.setBrush(self._get_brush(properties))
+        self._scene.addItem(item)
         self._set_item_data(item)
 
     def draw_filled_polygon(self, points: Iterable[Vec3],
@@ -213,7 +212,10 @@ class PyQtBackend(Backend):
         polygon = qg.QPolygonF()
         for p in points:
             polygon.append(qc.QPointF(p.x, p.y))
-        item = self._scene.addPolygon(polygon, self._no_line, brush)
+        item = _CosmeticPolygon(polygon)
+        item.setPen(self._no_line)
+        item.setBrush(brush)
+        self._scene.addItem(item)
         self._set_item_data(item)
 
     def draw_text(self, text: str, transform: Matrix44, properties: Properties,
@@ -274,6 +276,27 @@ class PyQtBackend(Backend):
                 self._get_pen(properties),
                 self._no_fill
             )
+
+
+class _CosmeticPath(qw.QGraphicsPathItem):
+    def paint(self, painter: qg.QPainter, option: qw.QStyleOptionGraphicsItem,
+              widget: Optional[qw.QWidget] = None) -> None:
+        _set_cosmetic_brush(self, painter)
+        super().paint(painter, option, widget)
+
+
+class _CosmeticPolygon(qw.QGraphicsPolygonItem):
+    def paint(self, painter: qg.QPainter, option: qw.QStyleOptionGraphicsItem,
+              widget: Optional[qw.QWidget] = None) -> None:
+        _set_cosmetic_brush(self, painter)
+        super().paint(painter, option, widget)
+
+
+def _set_cosmetic_brush(item: qw.QGraphicsItem, painter: qg.QPainter) -> None:
+    """ like a cosmetic pen, this sets the brush pattern to appear the same independent of the view """
+    brush = item.brush()
+    brush.setTransform(painter.transform().inverted()[0])
+    item.setBrush(brush)
 
 
 def _extend_qt_path(qt_path: qg.QPainterPath, path: Path) -> None:


### PR DESCRIPTION
In AutoCAD the hatch patterns are view dependent (you can zoom in on them), so this change moves away from 'compliance' slightly, but I think it's a better compromise since the highly scaled hatch patterns are too blurry. It would be tricky to choose the correct scale because that would rely on having perfect knowledge of the CAD file units. This approach should look the same in all CAD files regardless of their units / scale.

If you prefer the patterns to be scaled up slightly (too much and they would be blurry again) then a call to `scale()` of the inverted painter transform would apply that scale globally.

before:
![image](https://user-images.githubusercontent.com/4923501/107674798-434a5480-6c8f-11eb-8d02-6bbe26046d95.png)

after:
![image](https://user-images.githubusercontent.com/4923501/107675294-d97e7a80-6c8f-11eb-8380-87397a98b037.png)


