### PR TITLE
Pass True to boolean hatch example call rather than 1

### DIFF
--- a/docs/source/tutorials/src/hatch/solid_hatch_islands.py
+++ b/docs/source/tutorials/src/hatch/solid_hatch_islands.py
@@ -16,21 +16,21 @@ hatch = msp.add_hatch(color=1, dxfattribs={
 
 # The first path has to set flag: 1 = external
 # flag const.BOUNDARY_PATH_POLYLINE is added (OR) automatically
-hatch.paths.add_polyline_path([(0, 0), (10, 0), (10, 10), (0, 10)], is_closed=1, flags=1)
+hatch.paths.add_polyline_path([(0, 0), (10, 0), (10, 10), (0, 10)], is_closed=True, flags=1)
 
 doc.saveas(OUTDIR / 'solid_hatch_islands_01.dxf')
 
 # The second path has to set flag: 16 = outermost
-hatch.paths.add_polyline_path([(1, 1), (9, 1), (9, 9), (1, 9)], is_closed=1, flags=16)
+hatch.paths.add_polyline_path([(1, 1), (9, 1), (9, 9), (1, 9)], is_closed=True, flags=16)
 
 doc.saveas(OUTDIR / 'solid_hatch_islands_02.dxf')
 
 # The third path has to set flag: 0 = default
-hatch.paths.add_polyline_path([(2, 2), (8, 2), (8, 8), (2, 8)], is_closed=1, flags=0)
+hatch.paths.add_polyline_path([(2, 2), (8, 2), (8, 8), (2, 8)], is_closed=True, flags=0)
 
 doc.saveas(OUTDIR / 'solid_hatch_islands_03.dxf')
 
 # The forth path has to set flag: 0 = default, and so on
-hatch.paths.add_polyline_path([(3, 3), (7, 3), (7, 7), (3, 7)], is_closed=1, flags=0)
+hatch.paths.add_polyline_path([(3, 3), (7, 3), (7, 7), (3, 7)], is_closed=True, flags=0)
 
 doc.saveas(OUTDIR / 'solid_hatch_islands_04.dxf')

--- a/docs/source/tutorials/src/hatch/solid_hatch_polyline_path.py
+++ b/docs/source/tutorials/src/hatch/solid_hatch_polyline_path.py
@@ -8,6 +8,6 @@ hatch = msp.add_hatch(color=2)  # by default a solid fill hatch with fill color=
 # every boundary path is always a 2D element
 # vertex format for the polyline path is: (x, y[, bulge])
 # there are no bulge values in this example
-hatch.paths.add_polyline_path([(0, 0), (10, 0), (10, 10), (0, 10)], is_closed=1)
+hatch.paths.add_polyline_path([(0, 0), (10, 0), (10, 10), (0, 10)], is_closed=True)
 
 doc.saveas("solid_hatch_polyline_path.dxf")

--- a/docs/source/tutorials/src/hatch/solid_hatch_polyline_path_with_bulge.py
+++ b/docs/source/tutorials/src/hatch/solid_hatch_polyline_path_with_bulge.py
@@ -10,6 +10,6 @@ hatch = msp.add_hatch(color=2)  # by default a solid fill hatch with fill color=
 # bulge value 1 = an arc with diameter=10 (= distance to next vertex * bulge value)
 # bulge value > 0 ... arc is right of line
 # bulge value < 0 ... arc is left of line
-hatch.paths.add_polyline_path([(0, 0, 1), (10, 0), (10, 10, -0.5), (0, 10)], is_closed=1)
+hatch.paths.add_polyline_path([(0, 0, 1), (10, 0), (10, 10, -0.5), (0, 10)], is_closed=True)
 
 doc.saveas("solid_hatch_polyline_path_with_bulge.dxf")


### PR DESCRIPTION
The `is_closed` parameter expects a `bool` type. Update the Hatch tutorial to pass in `True` rather than `1`.