### PR TITLE
Fix issue with ezdxf.tools.guid()

### DIFF
--- a/src/ezdxf/tools/__init__.py
+++ b/src/ezdxf/tools/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2015-2018, Manfred Moitzi
 # License: MIT License
 from typing import Tuple, Any, Iterable
-from uuid import uuid1
+from uuid import uuid4
 import functools
 import html
 from .juliandate import juliandate, calendardate
@@ -56,8 +56,8 @@ def set_flag_state(flags: int, flag: int, state: bool = True) -> int:
 
 
 def guid() -> str:
-    """ Returns a general unique ID, based on :func:`uuid.uuid1`. """
-    return str(uuid1()).upper()
+    """ Returns a general unique ID, based on :func:`uuid.uuid4`. """
+    return str(uuid4()).upper()
 
 
 def take2(iterable: Iterable) -> Tuple[Any, Any]:


### PR DESCRIPTION
Hi.

I am developing an application where I have to use this wonderful package and, simultaneously, load a .DLL using ctypes.
For some reason, if I used the .DLL, the code would exit without any error/exception. I've found out that the issue was on the ezdxf.toold.guid(), because it was using uuid1(). I don't now the exact details, but changing this to the uuid4() solved my problem. Bases on [this answer](https://stackoverflow.com/a/1785592) it should not be an issue.

Hope that a new version of ezdxf can be released quickly.

Thanks for this awesome package!