### PR TITLE
Define LW as Lightweight Polyline

### DIFF
--- a/docs/source/dxfentities/lwpolyline.rst
+++ b/docs/source/dxfentities/lwpolyline.rst
@@ -4,7 +4,7 @@ LWPolyline
 .. module:: ezdxf.entities
     :noindex:
 
-The LWPOLYLINE entity (Light Weight POLYLINE, `DXF Reference`_) is defined as 
+The LWPOLYLINE entity (Lightweight POLYLINE, `DXF Reference`_) is defined as 
 a single graphic entity, which differs from the old-style :class:`Polyline` 
 entity, which is defined as a group of sub-entities. :class:`LWPolyline` 
 display faster (in AutoCAD) and consume less disk space, it is a planar 

--- a/docs/source/dxfentities/lwpolyline.rst
+++ b/docs/source/dxfentities/lwpolyline.rst
@@ -4,12 +4,12 @@ LWPolyline
 .. module:: ezdxf.entities
     :noindex:
 
-The LWPOLYLINE entity (`DXF Reference`_) is defined as a single graphic entity,
-which differs from the old-style :class:`Polyline` entity, which is defined as
-a group of sub-entities. :class:`LWPolyline` display faster (in AutoCAD) and
-consume less disk space, it is a planar element, therefore all points are
-located in the :ref:`OCS` as (x, y)-tuples (:attr:`LWPolyline.dxf.elevation`
-is the z-axis value).
+The LWPOLYLINE entity (Light Weight POLYLINE, `DXF Reference`_) is defined as 
+a single graphic entity, which differs from the old-style :class:`Polyline` 
+entity, which is defined as a group of sub-entities. :class:`LWPolyline` 
+display faster (in AutoCAD) and consume less disk space, it is a planar 
+element, therefore all points are located in the :ref:`OCS` as (x, y)-tuples
+(:attr:`LWPolyline.dxf.elevation` is the z-axis value).
 
 
 .. versionchanged:: 0.8.9


### PR DESCRIPTION
I always wondered what the `LW` in `LWPOLYLINE` was. I was able to find a reference that makes sense:

https://www.cadtutor.net/forum/topic/48794-what-is-a-lwpolyline/?do=findComment&comment=403240

> A lightweight polyline (lwpolyline) is defined in the drawing database as a single graphic entity. The lwpolyline differs from the old-style polyline, which is defined as a group of subentities. Lwpolylines display faster and consume less disk space and RAM.

A more authoritative source: http://docs.autodesk.com/ACDMAC/2014/ENU/index.html?url=files/GUID-0A3004D1-1BF6-468A-9F69-4D0BA88857F2.htm,topicNumber=d30e319257

>A lightweight polyline (lwpolyline) is defined in the drawing database as a single graphic entity unlike the old-style polyline, which is defined as a group of subentities.
>
>Lwpolylines display faster and consume less disk space and RAM. As of AutoCAD Release 14, 3D polylines are always created as old-style polyline entities, and 2D polylines are created as lwpolyline entities, unless they are curved or fitted with the AutoCAD PEDIT command. When a drawing from an earlier release is opened in AutoCAD Release 14 or a later release, all 2D polylines convert to lwpolylines automatically, unless they have been curved or fitted or contain extended data (xdata).