### PR TITLE
Fixed RuntimeError when loading new document in cad_viewer

### DIFF
--- a/src/ezdxf/addons/drawing/qtviewer.py
+++ b/src/ezdxf/addons/drawing/qtviewer.py
@@ -114,6 +114,10 @@ class CADGraphicsViewWithOverlay(CADGraphicsView):
         self._selected_items = None
         self._selected_index = None
 
+    def begin_loading(self):
+        self.clear()
+        super().begin_loading()
+
     def drawForeground(self, painter: qg.QPainter, rect: qc.QRectF) -> None:
         super().drawForeground(painter, rect)
         if self._selected_items:


### PR DESCRIPTION
Since it was created, the cad_viewer had a problem where it occasionally crashes when loading a new document. The error wasn't in python so there was no traceback or anything which made it hard to debug so I left it.
The errors looked like
```
cad_viewer: line 11: 18408 Segmentation fault      (core dumped)
```

today I found that the crash can be triggered very consistently by creating a file like this:
```python
import ezdxf

if __name__ == '__main__':
    doc = ezdxf.new()
    layout = doc.modelspace()
    d = 1
    points = [(0, 0), (d, 0), (0, d), (d, d)]
    for box_x in range(100):
        for box_y in range(100):
            box_points = [(x + box_x, y + box_y) for x, y in points]
            s = layout.add_solid(box_points)
            s.rgb = (box_x, box_y, 48)
    doc.saveas('/tmp/boxes.dxf')
```
then opening it in the cad_viewer then repeatedly going to 'Select Document' and selecting the same file again. The error is:
```
Traceback (most recent call last):
  File "ezdxf/src/ezdxf/addons/drawing/qtviewer.py", line 121, in drawForeground
    r = item.sceneTransform().mapRect(item.boundingRect())
RuntimeError: wrapped C/C++ object of type _CosmeticPolygon has been deleted
```
This time, because a python object is involved there is a traceback I was able to get to the bottom of it.
It looks like if an element is selected while loading a new document, the `drawForeground` method tries to get the item bounding box but the item may have been deleted because it belongs to the now deleted scene. The fix for this is to clear the selection when loading is initiated.

This may not be a complete fix, there may still be race conditions because I'm not using any locking mechanisms or anything, however the rate of crashes is greatly reduced.