### PR TITLE
Include py.typed file in package to comply with PEP 561

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include NEWS.md README.md LICENSE
 include requirements.txt
+include src/ezdxf/py.typed
 recursive-include src/ezdxf/acc *.hpp *.cpp *.h *.c *.pxd *.pyx
 recursive-include tests *.py
 recursive-include tests/data *

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         'tools/font_face_cache.json',
         'tools/font_measurement_cache.json',
         'resources/*.png',
+        'py.typed',
     ]},
     entry_points={
         'console_scripts': [

--- a/src/ezdxf/py.typed
+++ b/src/ezdxf/py.typed
@@ -1,0 +1,2 @@
+# Instruct type checkers to look for inline type annotations in this package.
+# See PEP 561.


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0561/

`mypy` and other type checkers use the presence of a `py.typed` file in the root of the package to signal that the package has inline type annotations to be used for type checking. Including this file allows users of this library to properly type check their usage of this package.