### PR TITLE
added basic OLE2FRAME drawing support

### DIFF
--- a/src/ezdxf/addons/drawing/properties.py
+++ b/src/ezdxf/addons/drawing/properties.py
@@ -52,6 +52,7 @@ table_key = layer_key
 MODEL_SPACE_BG_COLOR = "#212830"
 PAPER_SPACE_BG_COLOR = "#ffffff"
 VIEWPORT_COLOR = "#aaaaaa"  # arbitrary choice
+OLE2FRAME_COLOR = "#89adba"  # arbitrary choice
 
 
 def is_dark_color(color: Color, dark: float = 0.2) -> bool:


### PR DESCRIPTION
for me, OLE2FRAME entities are are in the same category as Viewport: I don't really care what they contain but I would like to know that they are there.

Currently OLE2FRAME entities are skipped but I think it would be better for the frontend to handle these entities when identified. In the future someone could expand on the `draw_ole_frame_entity` method to draw the entity properly if they want to.

I know that this implementation isn't ideal as it reads dxf tags directly, but it's quite simple and adds the minimum support for the entity needed to draw it as a rectangle. If this isn't sufficient I can make some improvements with your guidance.

