### PR TITLE
Layout colors fix

### DIFF
--- a/src/ezdxf/addons/drawing/frontend.py
+++ b/src/ezdxf/addons/drawing/frontend.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020-2021, Matthew Broadway
 # License: MIT License
 import math
-from typing import Iterable, cast, Union, List, Dict, Callable, Tuple, Set
+from typing import Iterable, cast, Union, List, Dict, Callable, Tuple, Set, Optional
 from ezdxf.lldxf import const
 from ezdxf.addons.drawing.backend import Backend
 from ezdxf.addons.drawing.properties import (
@@ -10,6 +10,7 @@ from ezdxf.addons.drawing.properties import (
     OLE2FRAME_COLOR,
     Properties,
     Filling,
+    LayoutProperties,
 )
 from ezdxf.addons.drawing.text import simplified_text_chunks
 from ezdxf.addons.drawing.type_hints import FilterFunc
@@ -173,8 +174,12 @@ class Frontend:
         finalize: bool = True,
         *,
         filter_func: FilterFunc = None,
+        layout_properties: Optional[LayoutProperties] = None,
     ) -> None:
-        self.ctx.set_current_layout(layout)
+        if layout_properties is not None:
+            self.ctx.current_layout = layout_properties
+        else:
+            self.ctx.set_current_layout(layout)
         self.parent_stack = []
         handle_mapping = list(layout.get_redraw_order())
         if handle_mapping:

--- a/src/ezdxf/addons/drawing/matplotlib.py
+++ b/src/ezdxf/addons/drawing/matplotlib.py
@@ -15,7 +15,7 @@ from matplotlib.textpath import TextPath
 import numpy as np
 
 from ezdxf.addons.drawing.backend import Backend, prepare_string_for_rendering
-from ezdxf.addons.drawing.properties import Properties
+from ezdxf.addons.drawing.properties import Properties, LayoutProperties
 from ezdxf.addons.drawing.type_hints import FilterFunc
 from ezdxf.tools.fonts import FontMeasurements
 from ezdxf.addons.drawing.type_hints import Color
@@ -420,14 +420,15 @@ def qsave(
         fig: plt.Figure = plt.figure()
         ax: plt.Axes = fig.add_axes((0, 0, 1, 1))
         ctx = RenderContext(layout.doc)
-        ctx.set_current_layout(layout)
+        layout_properties = LayoutProperties.from_layout(layout)
         if bg is not None:
-            ctx.current_layout.set_colors(bg, fg)
+            layout_properties.set_colors(bg, fg)
         out = MatplotlibBackend(ax, params=params)
         Frontend(ctx, out).draw_layout(
             layout,
             finalize=True,
             filter_func=filter_func,
+            layout_properties=layout_properties,
         )
         # transparent=True sets the axes color to fully transparent
         # facecolor sets the figure color

--- a/src/ezdxf/addons/drawing/properties.py
+++ b/src/ezdxf/addons/drawing/properties.py
@@ -229,11 +229,11 @@ class LayoutProperties:
         return self._has_dark_background
 
     @staticmethod
-    def modelspace(units: Optional[int] = None) -> "LayoutProperties":
+    def modelspace(units: int = 0) -> "LayoutProperties":
         return LayoutProperties('Model', MODEL_SPACE_BG_COLOR, units=units)
 
     @staticmethod
-    def paperspace(name: str = '', units: Optional[int] = None) -> "LayoutProperties":
+    def paperspace(name: str = '', units: int = 0) -> "LayoutProperties":
         return LayoutProperties(name, PAPER_SPACE_BG_COLOR, units=units)
 
     @staticmethod

--- a/src/ezdxf/addons/drawing/properties.py
+++ b/src/ezdxf/addons/drawing/properties.py
@@ -38,8 +38,10 @@ if TYPE_CHECKING:
 __all__ = [
     "Properties",
     "LayerProperties",
+    "LayoutProperties",
     "RenderContext",
     "layer_key",
+    "is_valid_color",
     "rgb_to_hex",
     "hex_to_rgb",
     "MODEL_SPACE_BG_COLOR",
@@ -211,25 +213,27 @@ class LayoutProperties:
         """Returns ``True`` if the actual background-color is "dark"."""
         return self._has_dark_background
 
-    def set_layout(
-        self,
+    @staticmethod
+    def from_layout(
         layout: "Layout",
         bg: Optional[Color] = None,
         fg: Optional[Color] = None,
         units: Optional[int] = None,
-    ) -> None:
+    ) -> "LayoutProperties":
         """Setup default layout properties."""
-        self.name = layout.name
+        properties = LayoutProperties()
+        properties.name = layout.name
         if bg is None:
-            if self.name == "Model":
+            if properties.name == "Model":
                 bg = MODEL_SPACE_BG_COLOR
             else:
                 bg = PAPER_SPACE_BG_COLOR
-        self.set_colors(bg, fg)
+        properties.set_colors(bg, fg)
         if units is None:
-            self.units = layout.units
+            properties.units = layout.units
         else:
-            self.units = int(units)
+            properties.units = int(units)
+        return properties
 
     def set_colors(self, bg: Color, fg: Color = None) -> None:
         """Setup default layout colors.
@@ -426,7 +430,7 @@ class RenderContext:
                 layer.is_visible = not state
 
     def set_current_layout(self, layout: "Layout"):
-        self.current_layout.set_layout(layout, units=self.units)
+        self.current_layout = LayoutProperties.from_layout(layout, units=self.units)
 
     @property
     def inside_block_reference(self) -> bool:

--- a/src/ezdxf/tools/pattern.py
+++ b/src/ezdxf/tools/pattern.py
@@ -10,7 +10,7 @@ from ._iso_pattern import ISO_PATTERN
 
 __all__ = [
     'load', 'scale_pattern', 'scale_all', 'parse', 'ISO_PATTERN',
-    'IMPERIAL_PATTERN', 'PatternAnalyser'
+    'IMPERIAL_PATTERN', 'HatchPatternLineType', 'HatchPatternType', 'PatternAnalyser'
 ]
 IMPERIAL_SCALE_FACTOR = 1.0 / 25.4
 HatchPatternLineType = Tuple[


### PR DESCRIPTION
fixes #508 by adding better control over the `LayoutProperties` used by the drawing frontend.

`RenderContext.set_current_layout()` isn't sufficient for full control over `LayoutProperties` since most attributes are not stored in the dxf object (eg background color) but are instead inferred. However the most common case is still to take the properties derived directly from a layout so I think it makes sense to keep this as a helper method?

Or you could remove `set_current_layout` and require using `ctx.current_layout = LayoutProperties.from_layout(mylayout)` which is still clear, but more verbose. Also I'm not sure about the name `current_layout` because it might imply the type is `Layout` rather than `LayoutProperties` but so long as the documentation is clear it shouldn't be an issue.


So to control the background color with the approach from the pull request:
```python
layout_properties = LayoutProperties.from_layout(my_layout)
layout_properties.set_colors(bg='#FF0000')

Frontend(ctx, out).draw_layout(my_layout, layout_properties=layout_properties)
```

To draw a paperspace layout as if it's a modelspace:
```python
Frontend(ctx, out).draw_layout(my_layout, layout_properties=LayoutProperties.modelspace())
```
