### PR TITLE
3DFACE: per edge visibility [WIP]

### DIFF
--- a/src/ezdxf/addons/drawing/properties.py
+++ b/src/ezdxf/addons/drawing/properties.py
@@ -504,6 +504,8 @@ class RenderContext:
         if dxftype == "INSERT":
             # depends only on the invisible flag, the layer state has no effect!
             return not bool(entity.dxf.invisible)
+        elif dxftype == "3DFACE":
+            return any(entity.get_edges_visibility())
 
         entity_layer = resolved_layer or layer_key(self.resolve_layer(entity))
         layer_properties = self.layers.get(entity_layer)

--- a/src/ezdxf/entities/solid.py
+++ b/src/ezdxf/entities/solid.py
@@ -189,7 +189,7 @@ class Face3d(_Base):
 
     def is_invisible_edge(self, num: int) -> bool:
         """Returns True if edge `num` is an invisible edge."""
-        if num < 0 or num >= self.num_vertices:
+        if num < 0 or num > 4:  # allow accessing 4th value even when triangle
             raise ValueError(f'invalid edge: {num}')
         return bool(self.dxf.invisible & (1 << num))
 
@@ -197,7 +197,7 @@ class Face3d(_Base):
         """Set visibility of edge `num`, status `True` for visible, status
         `False` for invisible.
         """
-        if num < 0 or num >= self.num_vertices:
+        if num < 0 or num >= 4:  # allow accessing 4th value even when triangle
             raise ValueError(f'invalid edge: {num}')
         if not visible:
             self.dxf.invisible = self.dxf.invisible | (1 << num)

--- a/tests/test_02_dxf_graphics/test_205_solid.py
+++ b/tests/test_02_dxf_graphics/test_205_solid.py
@@ -190,7 +190,16 @@ def test_3dface():
     assert face.is_invisible_edge(0) is False
     assert face.is_invisible_edge(1) is True
     assert face.is_invisible_edge(2) is False
-    assert face.is_invisible_edge(3) is True
+    assert face.is_invisible_edge(3) is True  # accessible even when triangle
+
+    assert face.get_edges_visibility() == [True, False, True]
+    assert face.is_triangle
+    assert face.num_vertices == 3
+
+    face.dxf.vtx3 = (1, 2, 3)
+    assert face.get_edges_visibility() == [True, False, True, False]
+    assert not face.is_triangle
+    assert face.num_vertices == 4
 
     face.dxf.invisible = 0
     face.set_edge_visibility(3, False)
@@ -263,6 +272,9 @@ def test_3dface_quad_vertices():
     face = Face3d()
     for index, vertex in enumerate([(0, 0), (1, 0), (1, 1), (0, 1)]):
         face[index] = vertex
+    assert not face.is_triangle
+    assert face.get_edges_visibility() == [True, True, True, True]
+    assert face.num_vertices == 4
     # no weird vertex order:
     assert face.wcs_vertices() == [(0, 0), (1, 0), (1, 1), (0, 1)]
     assert face.wcs_vertices(close=True) == [(0, 0), (1, 0), (1, 1), (0, 1),
@@ -273,6 +285,9 @@ def test_3dface_triangle_vertices():
     face = Face3d()
     for index, vertex in enumerate([(0, 0), (1, 0), (1, 1), (1, 1)]):
         face[index] = vertex
+    assert face.is_triangle
+    assert face.get_edges_visibility() == [True, True, True]
+    assert face.num_vertices == 3
     assert face.wcs_vertices() == [(0, 0), (1, 0), (1, 1)]
     assert face.wcs_vertices(close=True) == [(0, 0), (1, 0), (1, 1), (0, 0)]
 


### PR DESCRIPTION
The individual edges of a 3DFACE entity can be visible or hidden. Previously the `RenderContext` would cast `entity.dxf.invisible` to a bool to determine whether a 3DFACE is visible or not. For 3DFACE this field is a bit mask specifying the invisibility of each edge rather than the visibility of the entire entity, so if any edge was not visible the entire entity would be skipped.

With this pull request the entity is considered visible if any of it's edges are visible and the frontend considers two cases:
- the case where every edge is visible: draw as a path like before
- the case where one or more edges are invisible: draw the visible edges as individual lines

I did consider using `move_to` and always drawing as a path but that may complicate the backend as currently `move_to` commands are not expected in the middle of paths.

There are some examples whose visibility is still incorrect. I think the fix for this would involve changing how 3DFACE is handled. At the moment the rectangle and triangle cases are treated distinctly but I'm not sure if this is a good idea, because I think the more general case is that one or more points are identical. This can take many forms such as the 'lines' in the examples below. Also in the unit test a newly created Face3d is a 'triangle' because all it's vertices are (0, 0, 0). In terms of drawing the entity I think it would be fine for the frontend to unconditionally draw 4 edges for every 3DFACE even if some lines have 0 length, and the backend should filter those out. Since ezdxf isn't just used for drawing I'm not sure if any other components find the quad/tri distinction useful which is why I'm asking rather than just changing it.

[3dface.dxf.zip](https://github.com/mozman/ezdxf/files/6907963/3dface.dxf.zip)


AutoCAD:
![3dface](https://user-images.githubusercontent.com/4923501/127663750-581bf328-98c4-47ea-a172-ef7fbc71bbc7.png)

Ezdxf:
![image](https://user-images.githubusercontent.com/4923501/127663852-2634105f-4719-413f-8c29-359335700505.png)
