### PR TITLE
face3d always creates a consistent number of vertices

### DIFF
--- a/src/ezdxf/entities/solid.py
+++ b/src/ezdxf/entities/solid.py
@@ -189,7 +189,7 @@ class Face3d(_Base):
 
     def is_invisible_edge(self, num: int) -> bool:
         """Returns True if edge `num` is an invisible edge."""
-        if num < 0 or num > 4:  # allow accessing 4th value even when triangle
+        if num < 0 or num > 4:
             raise ValueError(f'invalid edge: {num}')
         return bool(self.dxf.invisible & (1 << num))
 
@@ -197,7 +197,7 @@ class Face3d(_Base):
         """Set visibility of edge `num`, status `True` for visible, status
         `False` for invisible.
         """
-        if num < 0 or num >= 4:  # allow accessing 4th value even when triangle
+        if num < 0 or num >= 4:
             raise ValueError(f'invalid edge: {num}')
         if not visible:
             self.dxf.invisible = self.dxf.invisible | (1 << num)
@@ -207,18 +207,7 @@ class Face3d(_Base):
     def get_edges_visibility(self) -> List[bool]:
         # if the face is a triangle, a fourth visibility flag
         # may be present but is ignored
-        return [not self.is_invisible_edge(i) for i in range(self.num_vertices)]
-
-    @property
-    def is_triangle(self) -> bool:
-        dxf = self.dxf
-        return (not dxf.hasattr("vtx3")
-                or dxf.vtx3 == dxf.vtx2
-                or dxf.vtx3 == dxf.vtx0)
-
-    @property
-    def num_vertices(self) -> int:
-        return 3 if self.is_triangle else 4
+        return [not self.is_invisible_edge(i) for i in range(4)]
 
     def load_dxf_attribs(
         self, processor: SubclassProcessor = None
@@ -250,19 +239,17 @@ class Face3d(_Base):
         return self
 
     def wcs_vertices(self, close: bool = False) -> List[Vec3]:
-        """Returns WCS vertices, if argument `close` is
-        ``True``, last vertex == first vertex.
-        Does **not** return duplicated last vertex if represents a triangle.
+        """Returns WCS vertices, if argument `close` is ``True``,
+        last vertex == first vertex.
+
+        returns 4 vertices when close=False and 5 vertices when close=True.
+        Some edges may have 0 length.
 
         Compatibility interface to SOLID and TRACE. The 3DFACE entity returns
         already WCS vertices.
-
         """
         dxf = self.dxf
-        vertices = [dxf.vtx0, dxf.vtx1, dxf.vtx2]
-        if not self.is_triangle:
-            vertices.append(dxf.vtx3)
-
-        if close and not vertices[0].isclose(vertices[-1]):
+        vertices = [dxf.vtx0, dxf.vtx1, dxf.vtx2, dxf.vtx3]
+        if close:
             vertices.append(vertices[0])
         return vertices

--- a/src/ezdxf/path/converter.py
+++ b/src/ezdxf/path/converter.py
@@ -467,7 +467,8 @@ def from_vertices(vertices: Iterable["Vertex"], close=False) -> Path:
         return Path()
     path = Path(start=vertices[0])
     for vertex in vertices[1:]:
-        path.line_to(vertex)
+        if not path.end.isclose(vertex):
+            path.line_to(vertex)
     if close:
         path.close()
     return path

--- a/tests/test_02_dxf_graphics/test_205_solid.py
+++ b/tests/test_02_dxf_graphics/test_205_solid.py
@@ -190,16 +190,12 @@ def test_3dface():
     assert face.is_invisible_edge(0) is False
     assert face.is_invisible_edge(1) is True
     assert face.is_invisible_edge(2) is False
-    assert face.is_invisible_edge(3) is True  # accessible even when triangle
+    assert face.is_invisible_edge(3) is True
 
-    assert face.get_edges_visibility() == [True, False, True]
-    assert face.is_triangle
-    assert face.num_vertices == 3
+    assert face.get_edges_visibility() == [True, False, True, False]
 
     face.dxf.vtx3 = (1, 2, 3)
     assert face.get_edges_visibility() == [True, False, True, False]
-    assert not face.is_triangle
-    assert face.num_vertices == 4
 
     face.dxf.invisible = 0
     face.set_edge_visibility(3, False)
@@ -272,9 +268,7 @@ def test_3dface_quad_vertices():
     face = Face3d()
     for index, vertex in enumerate([(0, 0), (1, 0), (1, 1), (0, 1)]):
         face[index] = vertex
-    assert not face.is_triangle
     assert face.get_edges_visibility() == [True, True, True, True]
-    assert face.num_vertices == 4
     # no weird vertex order:
     assert face.wcs_vertices() == [(0, 0), (1, 0), (1, 1), (0, 1)]
     assert face.wcs_vertices(close=True) == [(0, 0), (1, 0), (1, 1), (0, 1),
@@ -285,11 +279,10 @@ def test_3dface_triangle_vertices():
     face = Face3d()
     for index, vertex in enumerate([(0, 0), (1, 0), (1, 1), (1, 1)]):
         face[index] = vertex
-    assert face.is_triangle
-    assert face.get_edges_visibility() == [True, True, True]
-    assert face.num_vertices == 3
-    assert face.wcs_vertices() == [(0, 0), (1, 0), (1, 1)]
-    assert face.wcs_vertices(close=True) == [(0, 0), (1, 0), (1, 1), (0, 0)]
+    assert face.get_edges_visibility() == [True, True, True, True]
+    assert face.wcs_vertices() == [(0, 0), (1, 0), (1, 1), (1, 1)]
+    assert face.wcs_vertices(close=True) == [(0, 0), (1, 0), (1, 1), (1, 1),
+                                             (0, 0)]
 
 
 def test_elevation_group_code_support():


### PR DESCRIPTION
the second part to #513 
With this change there is no distinction between a 3D face which represents a rectangle and one that represents a triangle. This means that a consistent number of vertices is returned from `wcs_vertices` which makes the edge visibility easier to interpret.

With this change the 3dface example renders exactly how it appears in autocad:
![image](https://user-images.githubusercontent.com/4923501/127844871-44cb3a9b-65fb-4b9a-8f44-2261fc183669.png)
