### PR TITLE
improved configuration of the drawing addon

### DIFF
--- a/src/ezdxf/addons/drawing/config.py
+++ b/src/ezdxf/addons/drawing/config.py
@@ -113,23 +113,41 @@ class Configuration:
         nested_polygon_detection: required to draw polygons with holes, can be disabled
     """
 
-    pdsize: Optional[int] = 1
-    pdmode: Optional[int] = 0
-    measurement: Optional[int] = None
-    show_defpoints: bool = False
-    proxy_graphic_policy: ProxyGraphicPolicy = ProxyGraphicPolicy.SHOW
-    line_policy: LinePolicy = LinePolicy.APPROXIMATE
-    hatch_policy: HatchPolicy = HatchPolicy.SHOW_APPROXIMATE_PATTERN
-    infinite_line_length: float = 20
-    lineweight_scaling: float = 1.0
-    min_lineweight: Optional[float] = None
-    min_dash_length: float = 0.1
-    max_flattening_distance: float = disassemble.Primitive.max_flattening_distance
-    circle_approximation_count: int = 128
-    approximation_max_sagitta = 0.01
-    nested_polygon_detection: NestedPolygonDetectionMethod = (
-        NestedPolygonDetectionMethod.FAST
-    )
+    pdsize: Optional[int]
+    pdmode: Optional[int]
+    measurement: Optional[int]
+    show_defpoints: bool
+    proxy_graphic_policy: ProxyGraphicPolicy
+    line_policy: LinePolicy
+    hatch_policy: HatchPolicy
+    infinite_line_length: float
+    lineweight_scaling: float
+    min_lineweight: Optional[float]
+    min_dash_length: float
+    max_flattening_distance: float
+    circle_approximation_count: int
+    approximation_max_sagitta: float
+    nested_polygon_detection: NestedPolygonDetectionMethod
+
+    @staticmethod
+    def defaults() -> "Configuration":
+        return Configuration(
+            pdsize=1,
+            pdmode=0,
+            measurement=None,
+            show_defpoints=False,
+            proxy_graphic_policy=ProxyGraphicPolicy.SHOW,
+            line_policy=LinePolicy.APPROXIMATE,
+            hatch_policy=HatchPolicy.SHOW_APPROXIMATE_PATTERN,
+            infinite_line_length=20,
+            lineweight_scaling=1.0,
+            min_lineweight=None,
+            min_dash_length=0.1,
+            max_flattening_distance=disassemble.Primitive.max_flattening_distance,
+            circle_approximation_count=128,
+            approximation_max_sagitta=0.01,
+            nested_polygon_detection=NestedPolygonDetectionMethod.FAST,
+        )
 
     def with_changes(self, **kwargs) -> "Configuration":
         params = dataclasses.asdict(self)

--- a/src/ezdxf/addons/drawing/config.py
+++ b/src/ezdxf/addons/drawing/config.py
@@ -1,0 +1,138 @@
+import dataclasses
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Optional
+
+from ezdxf import disassemble
+
+
+class LinePolicy(Enum):
+    """
+    Attributes:
+        SOLID: draw all lines as solid regardless of the linetype style
+        APPROXIMATE: use the closest approximation available to the
+            backend for rendering styled lines
+        ACCURATE: analyse and render styled lines as accurately as
+            possible. This approach is slower and is not well suited
+            to interactive applications.
+    """
+
+    SOLID = auto()
+    APPROXIMATE = auto()
+    ACCURATE = auto()
+
+
+class ProxyGraphicPolicy(Enum):
+    """The action to take when an entity with a proxy graphic is encountered
+
+    Note: To get proxy graphics support proxy graphics have to be loaded:
+        Set the global option ezdxf.options.load_proxy_graphics to True.
+
+    Note: This can not prevent drawing proxy graphic inside of blocks,
+        because this is outside of the domain of the drawing add-on!
+
+    Attributes:
+        IGNORE: do not display proxy graphics (skip_entity will be called instead)
+        SHOW: if the entity cannot be rendered directly (eg if not implemented)
+            but a proxy is present: display the proxy
+        PREFER: display proxy graphics even for entities where direct rendering
+            is available
+    """
+
+    IGNORE = auto()
+    SHOW = auto()
+    PREFER = auto()
+
+
+class HatchPolicy(Enum):
+    """The action to take when a HATCH entity is encountered
+
+    Attributes:
+        IGNORE: do not show HATCH entities at all
+        SHOW_OUTLINE: show only the outline of HATCH entities
+        SHOW_SOLID: show HATCH entities but draw with solid fill
+            regardless of the pattern
+        SHOW_APPROXIMATE_PATTERN: show HATCH entities using the closest
+            approximation available to the current backend
+
+    """
+
+    IGNORE = auto()
+    SHOW_OUTLINE = auto()
+    SHOW_SOLID = auto()
+    SHOW_APPROXIMATE_PATTERN = auto()
+
+
+class NestedPolygonDetectionMethod(Enum):
+    NONE = auto()
+    FAST = auto()
+
+
+@dataclass(frozen=True)
+class Configuration:
+    """Configuration options for the rendering frontend
+
+    Attributes:
+        pdsize: the size to draw POINT entities (in drawing units)
+            set to None to use the $PDSIZE value from the dxf document header
+        pdmode: point styling mode (see POINT documentation)
+            0     5% of draw area height
+            <0    Specifies a percentage of the viewport size
+            >0    Specifies an absolute size
+            None  use the $PDMODE value from the dxf document header
+        measurement: whether to use metric or imperial units
+            0     use imperial units (in, ft, yd, ...)
+            1     use metric units (ISO meters)
+            None  use the $MEASUREMENT value from the dxf document header
+        show_defpoints: whether to show or filter out POINT entities on the defpoints layer
+        proxy_graphic_policy: the action to take when a proxy graphic is encountered
+        line_policy: the method to use when drawing styled lines (eg dashed, dotted etc)
+        hatch_policy: the method to use when drawing HATCH entities
+        infinite_line_length: the length to use when drawing infinite lines
+        lineweight_scaling:
+            set to 0.0 for a constant minimal width
+            the current result is correct, in SVG the line width is 0.7 points for 0.25mm as
+            required, but it often looks too thick
+        min_lineweight: the minimum line width in 1/300 inch
+            None    let the backend choose
+        min_dash_length: the minimum length for a dash when drawing a styled line
+            (default value is arbitrary)
+        max_flattening_distance: Max flattening distance in drawing units
+            see Path.flattening documentation.
+            The backend implementation should calculate an appropriate value,
+            like 1 screen- or paper pixel on the output medium, but converted
+            into drawing units. Sets Path() approximation accuracy
+        circle_approximation_count: Approximate a full circle by `n` segments, arcs
+            have proportional less segments
+        approximation_max_sagitta:
+            The sagitta (also known as the versine) is a line segment drawn
+            perpendicular to a chord, between the midpoint of that chord and the
+            arc of the circle. https://en.wikipedia.org/wiki/Circle not used yet!
+            Could be used for all curves CIRCLE, ARC, ELLIPSE and SPLINE
+            the default value of 0.01 => for drawing unit = 1m, max sagitta = 1cm
+        nested_polygon_detection: required to draw polygons with holes, can be disabled
+    """
+
+    pdsize: Optional[int] = 1
+    pdmode: Optional[int] = 0
+    measurement: Optional[int] = None
+    show_defpoints: bool = False
+    proxy_graphic_policy: ProxyGraphicPolicy = ProxyGraphicPolicy.SHOW
+    line_policy: LinePolicy = LinePolicy.APPROXIMATE
+    hatch_policy: HatchPolicy = HatchPolicy.SHOW_APPROXIMATE_PATTERN
+    infinite_line_length: float = 20
+    lineweight_scaling: float = 1.0
+    min_lineweight: Optional[float] = None
+    min_dash_length: float = 0.1
+    max_flattening_distance: float = disassemble.Primitive.max_flattening_distance
+    circle_approximation_count: int = 128
+    approximation_max_sagitta = 0.01
+    nested_polygon_detection: NestedPolygonDetectionMethod = (
+        NestedPolygonDetectionMethod.FAST
+    )
+
+    def with_changes(self, **kwargs) -> "Configuration":
+        params = dataclasses.asdict(self)
+        for k, v in kwargs.items():
+            params[k] = v
+        return Configuration(**params)

--- a/src/ezdxf/addons/drawing/debug_utils.py
+++ b/src/ezdxf/addons/drawing/debug_utils.py
@@ -2,12 +2,12 @@
 # License: MIT License
 from typing import List
 
-from ezdxf.addons.drawing.backend import Backend
+from ezdxf.addons.drawing.backend import BackendInterface
 from ezdxf.addons.drawing.type_hints import Color
 from ezdxf.math import Vec3
 
 
-def draw_rect(points: List[Vec3], color: Color, out: Backend):
+def draw_rect(points: List[Vec3], color: Color, out: BackendInterface):
     from ezdxf.addons.drawing import Properties
 
     props = Properties()

--- a/src/ezdxf/addons/drawing/frontend.py
+++ b/src/ezdxf/addons/drawing/frontend.py
@@ -12,8 +12,10 @@ from typing import (
     Set,
     Optional,
 )
+
+from ezdxf.addons.drawing.config import Configuration, ProxyGraphicPolicy, NestedPolygonDetectionMethod, HatchPolicy
 from ezdxf.lldxf import const
-from ezdxf.addons.drawing.backend import Backend
+from ezdxf.addons.drawing.backend import BackendInterface
 from ezdxf.addons.drawing.properties import (
     RenderContext,
     VIEWPORT_COLOR,
@@ -40,7 +42,6 @@ from ezdxf.entities import (
     Face3d,
     OLE2Frame,
     Point,
-    Mesh,
 )
 from ezdxf.entities.attrib import BaseAttrib
 from ezdxf.entities.polygon import DXFPolygon
@@ -62,70 +63,42 @@ from ezdxf.tools.text import has_inline_formatting_codes
 
 __all__ = ["Frontend"]
 
-INFINITE_LINE_LENGTH = 25
-DEFAULT_PDSIZE = 1
-
-IGNORE_PROXY_GRAPHICS = 0
-USE_PROXY_GRAPHICS = 1
-PREFER_PROXY_GRAPHICS = 2
 
 # typedef
 TDispatchTable = Dict[str, Callable[[DXFGraphic, Properties], None]]
 
 
 class Frontend:
-    """Drawing frontend, responsible for decomposing entities into graphic
+    """ Drawing frontend, responsible for decomposing entities into graphic
     primitives and resolving entity properties.
 
     Args:
-        ctx: actual render context of a DXF document
-        out: backend
-        proxy_graphics: o to ignore proxy graphics, 1 to show proxy graphics
-            and 2 to prefer proxy graphics over internal renderings
+        ctx: the properties relevant to rendering derived from a DXF document
+        out: the backend to draw to
+        config: settings to configure the drawing frontend and backend
 
     """
 
     def __init__(
         self,
         ctx: RenderContext,
-        out: Backend,
-        *,
-        proxy_graphics: int = USE_PROXY_GRAPHICS,
+        out: BackendInterface,
+        config: Configuration = Configuration()
     ):
         # RenderContext contains all information to resolve resources for a
         # specific DXF document.
         self.ctx = ctx
         self.out = out
+        self.config = ctx.update_configuration(config)
 
-        # To get proxy graphics support proxy graphics have to be loaded:
-        # Set the global option ezdxf.options.load_proxy_graphics to True.
-        # How to handle proxy graphics:
-        # 0 = ignore proxy graphics
-        # 1 = use proxy graphics if no rendering support by ezdxf exist
-        # 2 = prefer proxy graphics over ezdxf rendering
-        # This can not prevent drawing proxy graphic inside of blocks,
-        # because this is outside of the domain of the drawing add-on!
-        self.proxy_graphics = proxy_graphics
+        if self.config.pdsize is None or self.config.pdsize <= 0:
+            self.log_message('relative point size is not supported')
+            self.config = self.config.with_changes(pdsize=1)
 
-        # Transfer render context info to backend:
-        ctx.update_backend_configuration(out)
+        self.out.configure(self.config)
 
         # Parents entities of current entity/sub-entity
         self.parent_stack: List[DXFGraphic] = []
-
-        # Approximate a full circle by `n` segments, arcs have proportional
-        # less segments
-        self.circle_approximation_count = 128
-
-        # The sagitta (also known as the versine) is a line segment drawn
-        # perpendicular to a chord, between the midpoint of that chord and the
-        # arc of the circle. https://en.wikipedia.org/wiki/Circle not used yet!
-        # Could be used for all curves CIRCLE, ARC, ELLIPSE and SPLINE
-        # self.approximation_max_sagitta = 0.01  # for drawing unit = 1m, max
-        # sagitta = 1cm
-
-        # set to None to disable nested polygon detection:
-        self.nested_polygon_detection = fast_bbox_detection
 
         self._dispatch = self._build_dispatch_table()
 
@@ -136,9 +109,7 @@ class Frontend:
             "ACAD_PROXY_ENTITY",
         }
 
-    def _build_dispatch_table(
-        self,
-    ) -> TDispatchTable:
+    def _build_dispatch_table(self) -> TDispatchTable:
         dispatch_table: TDispatchTable = {
             "POINT": self.draw_point_entity,
             "HATCH": self.draw_hatch_entity,
@@ -221,7 +192,7 @@ class Frontend:
             entities = filter(filter_func, entities)
         for entity in entities:
             if not isinstance(entity, DXFGraphic):
-                if self.proxy_graphics != IGNORE_PROXY_GRAPHICS:
+                if self.config.proxy_graphic_policy != ProxyGraphicPolicy.IGNORE:
                     entity = DXFGraphicProxy(entity)
                 else:
                     self.skip_entity(entity, "Cannot parse DXF entity")
@@ -244,7 +215,7 @@ class Frontend:
         self.out.enter_entity(entity, properties)
         if (
             entity.proxy_graphic
-            and self.proxy_graphics == PREFER_PROXY_GRAPHICS
+            and self.config.proxy_graphic_policy == ProxyGraphicPolicy.PREFER
         ):
             self.draw_proxy_graphic(entity.proxy_graphic, entity.doc)
         else:
@@ -265,7 +236,7 @@ class Frontend:
                 # DXF entities (DXFGraphicProxy) do not get to this point if
                 # proxy graphic is ignored.
                 if (
-                    self.proxy_graphics != IGNORE_PROXY_GRAPHICS
+                    self.config.proxy_graphic_policy != ProxyGraphicPolicy.IGNORE
                     or entity.dxftype() not in self._proxy_graphic_only_entities
                 ):
                     self.draw_composite_entity(entity, properties)
@@ -283,7 +254,7 @@ class Frontend:
 
         elif dxftype in ("XLINE", "RAY"):
             start = d.start
-            delta = d.unit_vector * INFINITE_LINE_LENGTH
+            delta = d.unit_vector * self.config.infinite_line_length
             if dxftype == "XLINE":
                 self.out.draw_line(
                     start - delta / 2, start + delta / 2, properties
@@ -358,24 +329,24 @@ class Frontend:
         self, entity: DXFGraphic, properties: Properties
     ) -> None:
         point = cast(Point, entity)
-        pdmode = cast(int, self.out.pdmode)
+        pdmode = self.config.pdmode
+        pdsize = self.config.pdsize
+        assert pdmode is not None
+        assert pdsize is not None
 
         # Defpoints are regular POINT entities located at the "defpoints" layer:
         if properties.layer.lower() == "defpoints":
-            if not self.out.show_defpoints:
+            if not self.config.show_defpoints:
                 return
             else:  # Render defpoints as dimensionless points:
                 pdmode = 0
-
-        pdsize = cast(int, self.out.pdsize)
-        if pdsize <= 0:  # relative points size is not supported
-            pdsize = DEFAULT_PDSIZE
 
         if pdmode == 0:
             self.out.draw_point(entity.dxf.location, properties)
         else:
             for entity in point.virtual_entities(pdsize, pdmode):
-                if entity.dxftype() == "LINE":
+                dxftype = entity.dxftype()
+                if dxftype == "LINE":
                     start = Vec3(entity.dxf.start)
                     end = entity.dxf.end
                     if start.isclose(end):
@@ -383,8 +354,10 @@ class Frontend:
                     else:
                         self.out.draw_line(start, end, properties)
                     pass
-                else:  # CIRCLE
+                elif dxftype == 'CIRCLE':
                     self.draw_curve_entity(entity, properties)
+                else:
+                    raise ValueError(dxftype)
 
     def draw_solid_entity(
         self, entity: DXFGraphic, properties: Properties
@@ -419,7 +392,7 @@ class Frontend:
         *,
         loops: List[Path] = None,
     ) -> None:
-        if not self.out.show_hatch:
+        if self.config.hatch_policy == HatchPolicy.IGNORE:
             return
 
         polygon = cast(DXFPolygon, entity)
@@ -435,17 +408,19 @@ class Frontend:
         else:  # only HATCH
             paths = polygon.paths.rendering_paths(polygon.dxf.hatch_style)
 
-        if self.nested_polygon_detection:
+        if self.config.nested_polygon_detection == NestedPolygonDetectionMethod.FAST:
             if loops is None:  # only HATCH
                 loops = closed_loops(paths, ocs, elevation)
-            polygons: List = self.nested_polygon_detection(loops)
+            polygons: List = fast_bbox_detection(loops)
             external_paths, holes = winding_deconstruction(polygons)
-        else:  # only HATCH
+        elif self.config.nested_polygon_detection == NestedPolygonDetectionMethod.NONE:
             for p in paths:
                 if p.path_type_flags & const.BOUNDARY_PATH_EXTERNAL:
                     external_paths.extend(closed_loops(p, ocs, elevation))
                 else:
                     holes.extend(closed_loops(p, ocs, elevation))
+        else:
+            raise ValueError(self.config.nested_polygon_detection)
 
         if external_paths:
             self.out.draw_filled_paths(external_paths, holes, properties)
@@ -607,7 +582,7 @@ class Frontend:
                     elevation = Vec3(entity.dxf.elevation).z
 
             trace = TraceBuilder.from_polyline(
-                entity, segments=self.circle_approximation_count // 2
+                entity, segments=self.config.circle_approximation_count // 2
             )
             for polygon in trace.polygons():  # polygon is a sequence of Vec2()
                 if transform:

--- a/src/ezdxf/addons/drawing/frontend.py
+++ b/src/ezdxf/addons/drawing/frontend.py
@@ -83,7 +83,7 @@ class Frontend:
         self,
         ctx: RenderContext,
         out: BackendInterface,
-        config: Configuration = Configuration()
+        config: Configuration = Configuration.defaults()
     ):
         # RenderContext contains all information to resolve resources for a
         # specific DXF document.

--- a/src/ezdxf/addons/drawing/matplotlib.py
+++ b/src/ezdxf/addons/drawing/matplotlib.py
@@ -377,7 +377,7 @@ def qsave(
     fg: Optional[Color] = None,
     dpi: int = 300,
     backend: str = "agg",
-    config: Configuration = Configuration(),
+    config: Configuration = Configuration.defaults(),
     filter_func: FilterFunc = None,
 ) -> None:
     """Quick and simplified render export by matplotlib.

--- a/src/ezdxf/addons/drawing/mtext_complex.py
+++ b/src/ezdxf/addons/drawing/mtext_complex.py
@@ -1,18 +1,19 @@
 #  Copyright (c) 2021, Manfred Moitzi
 #  License: MIT License
-from typing import Iterable, List, Optional, Tuple
 import copy
 import math
+from typing import Iterable, List, Optional, Tuple
+
 from ezdxf import colors
-from ezdxf.lldxf import const
 from ezdxf.entities import MText
-from ezdxf.tools import text_layout as tl, fonts
+from ezdxf.lldxf import const
 from ezdxf.math import Matrix44, Vec3
 from ezdxf.render.abstract_mtext_renderer import AbstractMTextRenderer
-from .backend import Backend
+from ezdxf.tools import text_layout as tl, fonts
+from ezdxf.tools.text import MTextContext
+from .backend import BackendInterface
 from .properties import Properties, RenderContext, rgb_to_hex
 from .type_hints import Color
-from ezdxf.tools.text import MTextContext
 
 __all__ = ["complex_mtext_renderer"]
 
@@ -38,7 +39,7 @@ def corner_vertices(
 
 
 class FrameRenderer(tl.ContentRenderer):
-    def __init__(self, properties: Properties, backend: Backend):
+    def __init__(self, properties: Properties, backend: BackendInterface):
         self.properties = properties
         self.backend = backend
 
@@ -75,7 +76,7 @@ class ColumnBackgroundRenderer(FrameRenderer):
     def __init__(
         self,
         properties: Properties,
-        backend: Backend,
+        backend: BackendInterface,
         bg_properties: Properties = None,
         offset: float = 0,
         text_frame: bool = False,
@@ -117,7 +118,7 @@ class TextRenderer(FrameRenderer):
         width_factor: float,
         oblique: float,  # angle in degrees
         properties: Properties,
-        backend: Backend,
+        backend: BackendInterface,
     ):
         super().__init__(properties, backend)
         self.text = text
@@ -154,7 +155,7 @@ class TextRenderer(FrameRenderer):
 
 
 def complex_mtext_renderer(
-    ctx: RenderContext, backend: Backend, mtext: MText, properties: Properties
+    ctx: RenderContext, backend: BackendInterface, mtext: MText, properties: Properties
 ) -> None:
     cmr = ComplexMTextRenderer(ctx, backend, properties)
     align = tl.LayoutAlignment(mtext.dxf.attachment_point)
@@ -167,7 +168,7 @@ class ComplexMTextRenderer(AbstractMTextRenderer):
     def __init__(
         self,
         ctx: RenderContext,
-        backend: Backend,
+        backend: BackendInterface,
         properties: Properties,
     ):
         super().__init__()
@@ -253,7 +254,7 @@ class ComplexMTextRenderer(AbstractMTextRenderer):
     # Implementation details of ComplexMTextRenderer:
 
     @property
-    def backend(self) -> Backend:
+    def backend(self) -> BackendInterface:
         return self._backend
 
     def resolve_aci_color(self, aci: int) -> Color:

--- a/src/ezdxf/addons/drawing/properties.py
+++ b/src/ezdxf/addons/drawing/properties.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 from ezdxf.addons import acadctb
+from ezdxf.addons.drawing.config import Configuration
 from ezdxf.addons.drawing.type_hints import Color, RGB
 from ezdxf.colors import luminance, DXF_DEFAULT_COLORS, int2rgb
 from ezdxf.entities import Attrib, Insert, Face3d, Linetype
@@ -327,20 +328,18 @@ class RenderContext:
         self.current_layout_properties.units = self.units
         self._hatch_pattern_cache: Dict[str, HatchPatternType] = dict()
 
-    def update_backend_configuration(self, backend):
-        """Configuration parameters are stored in the backend and may be
-        changed by the backend at runtime. Some parameters are stored globally
-        in the header section of the DXF document. This method must be called
-        if a new DXF document was loaded.
-
+    def update_configuration(self, config: Configuration) -> Configuration:
+        """ Where the user has not specified a value, populate configuration
+        fields based on the dxf header values
         """
-        # This DXF document parameters are not accessible by the backend
-        # in a direct way:
-        if backend.pdsize is None:
-            backend.pdsize = self.pdsize
-        if backend.pdmode is None:
-            backend.pdmode = self.pdmode
-        backend.measurement = self.measurement
+        changes = {}
+        if config.pdsize is None:
+            changes['pdsize'] = self.pdsize
+        if config.pdmode is None:
+            changes['pdmode'] = self.pdmode
+        if config.measurement is None:
+            changes['measurement'] = self.measurement
+        return config.with_changes(**changes)
 
     def _setup_layers(self, doc: "Drawing"):
         for layer in doc.layers:

--- a/src/ezdxf/addons/drawing/qtviewer.py
+++ b/src/ezdxf/addons/drawing/qtviewer.py
@@ -167,7 +167,7 @@ class CADGraphicsViewWithOverlay(CADGraphicsView):
 
 
 class CadViewer(qw.QMainWindow):
-    def __init__(self, config: Configuration = Configuration()):
+    def __init__(self, config: Configuration = Configuration.defaults()):
         super().__init__()
         self._config = config
         self.doc = None

--- a/src/ezdxf/addons/drawing/qtviewer.py
+++ b/src/ezdxf/addons/drawing/qtviewer.py
@@ -13,6 +13,7 @@ from ezdxf import recover
 from ezdxf.addons import odafc
 from ezdxf.addons.drawing import Frontend, RenderContext
 from ezdxf.addons.drawing.backend import BackendScaler
+from ezdxf.addons.drawing.config import Configuration
 
 from ezdxf.addons.drawing.properties import is_dark_color
 from ezdxf.addons.drawing.pyqt import (
@@ -166,10 +167,10 @@ class CADGraphicsViewWithOverlay(CADGraphicsView):
 
 
 class CadViewer(qw.QMainWindow):
-    def __init__(self, params: Dict):
+    def __init__(self, config: Configuration = Configuration()):
         super().__init__()
+        self._config = config
         self.doc = None
-        self._render_params = params
         self._render_context = None
         self._visible_layers = None
         self._current_layout = None
@@ -223,7 +224,7 @@ class CadViewer(qw.QMainWindow):
         self.show()
 
     def _reset_backend(self, scale: float = 1.0):
-        backend = PyQtBackend(use_text_cache=True, params=self._render_params)
+        backend = PyQtBackend(use_text_cache=True)
         if scale != 1.0:
             backend = BackendScaler(backend, factor=scale)  # type: ignore
         # clear caches
@@ -350,6 +351,7 @@ class CadViewer(qw.QMainWindow):
         return Frontend(
             self._render_context,
             self._backend,
+            self._config,
         )
 
     def _update_render_context(self, layout):

--- a/src/ezdxf/addons/drawing/text.py
+++ b/src/ezdxf/addons/drawing/text.py
@@ -5,13 +5,13 @@ from math import radians
 from typing import Union, Tuple, Dict, Iterable, List, Optional, Callable
 
 import ezdxf.lldxf.const as DXFConstants
-from ezdxf.addons.drawing.backend import Backend
+from ezdxf.addons.drawing.backend import BackendInterface
 from ezdxf.addons.drawing.debug_utils import draw_rect
-from ezdxf.tools import fonts
 from ezdxf.entities import MText, Text, Attrib, AttDef
 from ezdxf.math import Matrix44, Vec3, sign
-from ezdxf.tools.text import plain_text, text_wrap
+from ezdxf.tools import fonts
 from ezdxf.tools.fonts import FontMeasurements
+from ezdxf.tools.text import plain_text, text_wrap
 
 """
 Search google for 'typography' or 'font anatomy' for explanations of terms like 
@@ -283,7 +283,7 @@ def _get_wcs_insert(text: AnyText) -> Vec3:
 # Simple but fast MTEXT renderer:
 def simplified_text_chunks(
     text: AnyText,
-    out: Backend,
+    out: BackendInterface,
     *,
     font: fonts.FontFace = None,
     debug_draw_rect: bool = False

--- a/src/ezdxf/disassemble.py
+++ b/src/ezdxf/disassemble.py
@@ -47,14 +47,14 @@ class Primitive(abc.ABC):
 
     max_flattening_distance: float = 0.01
 
-    def __init__(self, entity: DXFEntity, max_flattening_distance=None):
+    def __init__(self, entity: DXFEntity, max_flattening_distance: Optional[float] = None):
         self.entity: DXFEntity = entity
         # Path representation for linear entities:
         self._path: Optional[Path] = None
         # MeshBuilder representation for mesh based entities:
         # PolygonMesh, PolyFaceMesh, Mesh
         self._mesh: Optional[MeshBuilder] = None
-        if max_flattening_distance:
+        if max_flattening_distance is not None:
             self.max_flattening_distance = max_flattening_distance
 
     @property

--- a/src/ezdxf/render/dim_radius.py
+++ b/src/ezdxf/render/dim_radius.py
@@ -430,7 +430,7 @@ class RadiusDimension(BaseDimensionRenderer):
             self.dimension.dxf.extrusion = self.ucs.uz
 
 
-def add_center_mark(dim):
+def add_center_mark(dim: RadiusDimension) -> None:
     """Add center mark/lines to radius and diameter dimensions.
 
     Args:

--- a/tests/test_08_addons/test_811_drawing_frontend.py
+++ b/tests/test_08_addons/test_811_drawing_frontend.py
@@ -4,7 +4,8 @@ from typing import List, Set, cast
 import pytest
 import ezdxf
 from ezdxf.addons.drawing import Frontend, RenderContext, Properties
-from ezdxf.addons.drawing.backend import Backend, BackendScaler, DEFAULT_PARAMS
+from ezdxf.addons.drawing.backend import Backend, BackendScaler
+from ezdxf.addons.drawing.config import Configuration
 from ezdxf.tools.fonts import FontMeasurements
 from ezdxf.document import Drawing
 from ezdxf.entities import DXFGraphic
@@ -21,6 +22,7 @@ class BasicBackend(Backend):
     def __init__(self):
         super().__init__()
         self.collector = []
+        self.configure(Configuration())
 
     def draw_point(self, pos: Vec3, properties: Properties) -> None:
         self.collector.append(('point', pos, properties))
@@ -494,10 +496,6 @@ class TestBackendScaler:
     @pytest.fixture
     def backend(self):
         return BackendScaler(PathBackend(), 2)
-
-    def test_has_access_to_attributes(self, backend):
-        for k, v in DEFAULT_PARAMS.items():
-            assert getattr(backend, k) == v
 
     def test_can_call_delegate_methods(self, backend):
         backend.set_background("#000000")

--- a/tests/test_08_addons/test_811_drawing_frontend.py
+++ b/tests/test_08_addons/test_811_drawing_frontend.py
@@ -22,7 +22,7 @@ class BasicBackend(Backend):
     def __init__(self):
         super().__init__()
         self.collector = []
-        self.configure(Configuration())
+        self.configure(Configuration.defaults())
 
     def draw_point(self, pos: Vec3, properties: Properties) -> None:
         self.collector.append(('point', pos, properties))


### PR DESCRIPTION
following the discussion https://github.com/mozman/ezdxf/discussions/534 I have refactored the drawing addon configuration so that the backend is accessed through a strictly controlled interface rather than accessing and having the frontend and render context modify public attributes in-place.

The `Configuration` class is read only (frozen) so that the flow of data is easier to track. No longer can other parts of the system mutate values all over the place.

I also took the opportunity to replace some of the integer arguments with enums so that their possible values are clearer. I was not entirely sure about the purpose of some of the parameters, for example `lineweight_scale` vs `linetype_scale`. It seemed that `linetype_scale` is a hack where 1 => interpret line styles and 0 => draw solid lines but I'm not sure. I removed this parameter in favour of incorporating the 'draw solid' option into the `LinePolicy` enum.

There were a few tricky cases where it seems that different values are set for different backends. I think the overall configuration struct should be backend independent, and if a backend needs extra information to be able to follow those instructions then they should be given that information directly. For example the Qt backend has an `extra_lineweight_scaling` which allows it to scale line weights to match what the user would expect, rather than having the configuration object itself be influenced by which backend you are using. Similarly, the `min_lineweight` was being set in `qsave` so I changed that parameter to have a value (None) where the backends themselves will choose an appropriate value.

The configuration class could be split into parameters which are relevant to the frontend only and those which are to configure the line rendering etc but for now I have just collected all the parameters into a single class.
