### PR TITLE
Fix typo in browse-command config example for gedit

### DIFF
--- a/docs/source/launcher.rst
+++ b/docs/source/launcher.rst
@@ -321,7 +321,7 @@ For `gedit` on Linux use (untested):
 
     [browse-command]
 
-    text_editor = /use/bin/gedit +{num} "{filename}"
+    text_editor = /usr/bin/gedit +{num} "{filename}"
     icon_size = 32
 
 The *browse* command opens a DXF structure browser to investigate the


### PR DESCRIPTION
The result still doesn’t seem to work for me (on Fedora Linux 36) for reasons that seem to be related to quoting and/or argument splitting. I haven’t taken time to figure out exactly what is happening.

Still, this PR fixes the typo in the command path.