### PR TITLE
for make_path() bulges respect segments except hatch

### DIFF
--- a/docs/source/path.rst
+++ b/docs/source/path.rst
@@ -106,7 +106,7 @@ Functions to create :class:`Path` objects from other objects.
 
     :param entity: DXF entity
     :param segments: minimal count of cubic Bézier-curves for elliptical arcs
-        like CIRCLE, ARC, ELLIPSE, see :meth:`Path.add_ellipse`
+        like CIRCLE, ARC, ELLIPSE, BULGE see :meth:`Path.add_ellipse`
     :param level: subdivide level for SPLINE approximation,
         see :meth:`Path.add_spline`
 

--- a/src/ezdxf/path/converter.py
+++ b/src/ezdxf/path/converter.py
@@ -122,6 +122,7 @@ def _from_lwpolyline(lwpolyline: LWPolyline, **kwargs) -> "Path":
         close=lwpolyline.closed,
         ocs=lwpolyline.ocs(),
         elevation=lwpolyline.dxf.elevation,
+        segments=kwargs.get("segments", 1)
     )
     return path
 
@@ -152,6 +153,7 @@ def _from_polyline(polyline: Polyline, **kwargs) -> "Path":
         close=polyline.is_closed,
         ocs=ocs,
         elevation=elevation,
+        segments=kwargs.get("segments", 1)
     )
     return path
 

--- a/src/ezdxf/path/tools.py
+++ b/src/ezdxf/path/tools.py
@@ -696,7 +696,7 @@ def add_2d_polyline(
         path.end, rel_tol=IS_CLOSE_TOL, abs_tol=0
     ):
         if prev_bulge:
-            bulge_to(path.end, path.start, prev_bulge)
+            bulge_to(path.end, path.start, prev_bulge, segments)
         else:
             path.line_to(path.start)
 

--- a/src/ezdxf/path/tools.py
+++ b/src/ezdxf/path/tools.py
@@ -649,12 +649,13 @@ def add_2d_polyline(
     """
 
     def bulge_to(p1: Vec3, p2: Vec3, bulge: float, segments: int):
+        num_bez = math.ceil(segments / 3)  # each cubic_bezier adds 3 segments, need 1 minimum
         if p1.isclose(p2, rel_tol=IS_CLOSE_TOL, abs_tol=0):
             return
         center, start_angle, end_angle, radius = bulge_to_arc(p1, p2, bulge)
-        angles = list(linspace(start_angle, end_angle, segments + 1))
+        angles = list(linspace(start_angle, end_angle, num_bez + 1))
         curves = []
-        for i in range(segments):
+        for i in range(num_bez):
             ellipse = ConstructionEllipse.from_arc(
                 center,
                 radius,


### PR DESCRIPTION
1. converter.py: get segments from kwargs in 2/3 uses of add_2d_polyline (hatch doesn't have kwargs)
2. tools.py: add_2d_polyline(): bulge_to(): added segmentation of angles and loop
3. path.rst: Path Factory Function description added BULGE