### PR TITLE
Configurable cad view

### DIFF
--- a/docs/source/usage_for_beginners.rst
+++ b/docs/source/usage_for_beginners.rst
@@ -262,7 +262,7 @@ attribute :code:`doc.layers`.
 
 You can create your own layers::
 
-    my_layer = doc.layer.add("MyLayer")
+    my_layer = doc.layers.add("MyLayer")
 
 The layer object also controls the visibility of entities which references this
 layer, the on/off state of the layer is unfortunately stored as positive or

--- a/examples/addons/drawing/cad_viewer.py
+++ b/examples/addons/drawing/cad_viewer.py
@@ -9,7 +9,7 @@ from ezdxf.addons.xqt import QtWidgets as qw
 
 import ezdxf
 from ezdxf import recover
-from ezdxf.addons.drawing.qtviewer import CadViewer
+from ezdxf.addons.drawing.qtviewer import CADViewer
 from ezdxf.addons.drawing.config import Configuration
 
 # ------------------------------------------------------------------------------
@@ -38,7 +38,7 @@ def _main():
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)  # handle Ctrl+C properly
     app = qw.QApplication(sys.argv)
-    v = CadViewer(config=config)
+    v = CADViewer.from_config(config)
     if args.cad_file is not None:
         try:
             doc, auditor = recover.readfile(args.cad_file)

--- a/examples/addons/drawing/element_picker.py
+++ b/examples/addons/drawing/element_picker.py
@@ -1,0 +1,88 @@
+import argparse
+import signal
+import sys
+from typing import Optional
+
+import ezdxf
+from ezdxf import recover
+from ezdxf.addons.drawing.qtviewer import (
+    CADGraphicsViewWithOverlay,
+    CADWidget,
+    CADViewer,
+)
+from ezdxf.addons.xqt import QtCore as qc, QtGui as qg, QtWidgets as qw
+from ezdxf.audit import Auditor
+from ezdxf.document import Drawing
+from ezdxf.entities import DXFGraphic
+
+
+class ElementSelectorView(CADGraphicsViewWithOverlay):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.selected = None
+
+    def keyPressEvent(self, event: qg.QKeyEvent) -> None:
+        if event.key() == qc.Qt.Key_Return:
+            element = self.current_hovered_element
+            if element is not None:
+                self.selected = element
+                self.close()
+
+
+def select_element(
+    doc: Drawing, layout: str = "Model", show_controls: bool = False
+) -> Optional[DXFGraphic]:
+    app = qw.QApplication.instance()
+    if app is None:
+        signal.signal(signal.SIGINT, signal.SIG_DFL)  # handle Ctrl+C properly
+        app = qw.QApplication([])
+
+    view = ElementSelectorView()
+    cad = CADWidget(view)
+    if show_controls:
+        viewer = CADViewer(cad=cad)
+        view.closing.connect(viewer.close)
+        viewer.set_document(doc, Auditor(doc), layout=layout)
+        viewer.show()
+    else:
+        cad.set_document(doc, layout=layout)
+        cad.show()
+    app.exec()
+    return view.selected
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Press enter to select a CAD element")
+    parser.add_argument("cad_file", nargs="?")
+    parser.add_argument(
+        "--show_controls",
+        action="store_true",
+        help="whether to show GUI controls or just the CAD view",
+    )
+    parser.add_argument("--layout", default="Model", help="the layout to select from")
+    args = parser.parse_args()
+
+    if args.cad_file is None:
+        print("no CAD file specified")
+        sys.exit(1)
+
+    try:
+        doc = ezdxf.readfile(args.cad_file)
+    except IOError:
+        print(f"Not a DXF file or a generic I/O error.")
+        sys.exit(2)
+    except ezdxf.DXFError:
+        try:
+            doc, auditor = recover.readfile(args.cad_file)
+        except ezdxf.DXFStructureError:
+            print(f"Invalid or corrupted DXF file: {args.cad_file}")
+            sys.exit(3)
+
+    selected_element = select_element(
+        doc, layout=args.layout, show_controls=args.show_controls
+    )
+    print(f"element selected: {selected_element}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ezdxf/addons/drawing/qtviewer.py
+++ b/src/ezdxf/addons/drawing/qtviewer.py
@@ -3,7 +3,7 @@
 # License: MIT License
 # mypy: ignore_errors=True
 from __future__ import annotations
-from typing import Iterable, Sequence
+from typing import Iterable, Sequence, Set, Optional
 import math
 import os
 import time
@@ -31,11 +31,14 @@ from ezdxf.addons.drawing.pyqt import (
 )
 from ezdxf.audit import Auditor
 from ezdxf.document import Drawing
-from ezdxf.entities import DXFGraphic
+from ezdxf.entities import DXFGraphic, DXFEntity
+from ezdxf.layouts import Layout
 from ezdxf.lldxf.const import DXFStructureError
 
 
 class CADGraphicsView(qw.QGraphicsView):
+    closing = Signal()
+
     def __init__(
         self,
         *,
@@ -63,6 +66,13 @@ class CADGraphicsView(qw.QGraphicsView):
             | qg.QPainter.TextAntialiasing
             | qg.QPainter.SmoothPixmapTransform
         )
+
+        self.setScene(qw.QGraphicsScene())
+        self.scale(1, -1)  # so that +y is up
+
+    def closeEvent(self, event: qg.QCloseEvent) -> None:
+        super().closeEvent(event)
+        self.closing.emit()
 
     def clear(self):
         pass
@@ -126,12 +136,21 @@ class CADGraphicsView(qw.QGraphicsView):
 class CADGraphicsViewWithOverlay(CADGraphicsView):
 
     mouse_moved = Signal(qc.QPointF)
-    element_selected = Signal(object, int)
+    element_hovered = Signal(object, int)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._selected_items: list[qw.QGraphicsItem] = []
         self._selected_index = None
+
+    @property
+    def current_hovered_element(self) -> Optional[DXFEntity]:
+        if self._selected_items:
+            graphics_item = self._selected_items[self._selected_index]
+            dxf_entity = graphics_item.data(CorrespondingDXFEntity)
+            return dxf_entity
+        else:
+            return None
 
     def clear(self):
         super().clear()
@@ -168,30 +187,123 @@ class CADGraphicsViewWithOverlay(CADGraphicsView):
             self._emit_selected()
 
     def _emit_selected(self):
-        self.element_selected.emit(self._selected_items, self._selected_index)
+        self.element_hovered.emit(self._selected_items, self._selected_index)
         self.scene().invalidate(
             self.sceneRect(), qw.QGraphicsScene.ForegroundLayer
         )
 
 
-class CadViewer(qw.QMainWindow):
-    def __init__(self, config: Configuration = Configuration.defaults()):
+class CADWidget(qw.QWidget):
+    def __init__(self, view: CADGraphicsView, config: Configuration = Configuration.defaults()):
         super().__init__()
+        layout = qw.QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(view)
+        self.setLayout(layout)
+
+        self._view = view
+        self._view.closing.connect(self.close)
+
         self._config = config
+        self._bbox_cache = ezdxf.bbox.Cache()
+
         # Avoid using Optional[...], otherwise mypy requires None checks
         # everywhere!
-        self.doc: Drawing = None  # type: ignore
+        self._doc: Drawing = None  # type: ignore
         self._render_context: RenderContext = None  # type: ignore
         self._visible_layers: set[str] = set()
         self._current_layout: str = "Model"
         self._reset_backend()
-        self._bbox_cache = ezdxf.bbox.Cache()
 
-        self.view = CADGraphicsViewWithOverlay()
-        self.view.setScene(qw.QGraphicsScene())
-        self.view.scale(1, -1)  # so that +y is up
-        self.view.element_selected.connect(self._on_element_selected)
-        self.view.mouse_moved.connect(self._on_mouse_moved)
+    def _reset_backend(self):
+        # clear caches
+        self._backend = PyQtBackend()
+
+    @property
+    def doc(self) -> Drawing:
+        return self._doc
+
+    @property
+    def view(self) -> CADGraphicsView:
+        return self._view
+
+    @property
+    def render_context(self) -> RenderContext:
+        return self._render_context
+
+    def set_document(
+            self,
+            document: Drawing,
+            *,
+            layout: str = "Model",
+    ):
+        self._doc = document
+        # initialize bounding box cache for faste paperspace drawing
+        self._bbox_cache = ezdxf.bbox.Cache()
+        self._render_context = self._make_render_context(document)
+        self._reset_backend()
+        self._visible_layers = set()
+        self._current_layout = None
+        self.draw_layout(layout)
+
+    def set_visible_layers(self, layers: Set[str]) -> None:
+        self._visible_layers = layers
+        self.draw_layout(self._current_layout, reset_view=False)
+
+    def _make_render_context(self, doc: Drawing) -> RenderContext:
+        def update_layers_state(layers: Sequence[LayerProperties]):
+            if self._visible_layers:
+                set_layers_state(layers, self._visible_layers, state=True)
+
+        render_context = RenderContext(doc)
+        render_context.set_layer_properties_override(update_layers_state)
+        return render_context
+
+    def draw_layout(
+            self,
+            layout_name: str,
+            reset_view: bool = True,
+    ):
+        self._current_layout = layout_name
+        self._view.begin_loading()
+        new_scene = qw.QGraphicsScene()
+        self._backend.set_scene(new_scene)
+        layout = self._doc.layout(layout_name)
+        self._update_render_context(layout)
+        try:
+            self._create_frontend().draw_layout(layout)
+        finally:
+            self._backend.finalize()
+        self._view.end_loading(new_scene)
+        self._view.buffer_scene_rect()
+        if reset_view:
+            self._view.fit_to_scene()
+
+    def _create_frontend(self) -> Frontend:
+        return Frontend(
+            ctx=self._render_context,
+            out=self._backend,
+            config=self._config,
+            bbox_cache=self._bbox_cache
+        )
+
+    def _update_render_context(self, layout: Layout) -> None:
+        assert self._render_context is not None
+        self._render_context.set_current_layout(layout)
+
+
+class CADViewer(qw.QMainWindow):
+    def __init__(self, cad: Optional[CADWidget] = None):
+        super().__init__()
+        if cad is None:
+            self._cad = CADWidget(CADGraphicsViewWithOverlay(), config=Configuration.defaults())
+        else:
+            self._cad = cad
+        self._view = self._cad.view
+
+        if isinstance(self._view, CADGraphicsViewWithOverlay):
+            self._view.element_hovered.connect(self._on_element_hovered)
+            self._view.mouse_moved.connect(self._on_mouse_moved)
 
         menu = self.menuBar()
         select_doc_action = QAction("Select Document", self)
@@ -223,7 +335,7 @@ class CadViewer(qw.QMainWindow):
 
         container = qw.QSplitter()
         self.setCentralWidget(container)
-        container.addWidget(self.view)
+        container.addWidget(self._cad)
         container.addWidget(self.sidebar)
         container.setCollapsible(0, False)
         container.setCollapsible(1, True)
@@ -234,9 +346,13 @@ class CadViewer(qw.QMainWindow):
         self.resize(1600, 900)
         self.show()
 
-    def _reset_backend(self):
-        # clear caches
-        self._backend = PyQtBackend()
+    @staticmethod
+    def from_config(config: Configuration) -> CADViewer:
+        return CADViewer(cad=CADWidget(CADGraphicsViewWithOverlay(), config=config))
+
+    def _create_cad_widget(self):
+        self._view = CADGraphicsViewWithOverlay()
+        self._cad = CADWidget(self._view)
 
     def _select_doc(self):
         path, _ = qw.QFileDialog.getOpenFileName(
@@ -285,31 +401,15 @@ class CadViewer(qw.QMainWindow):
                 auditor.print_error_report(auditor.errors)
                 return
 
-        self.doc = document
-        # initialize bounding box cache for faste paperspace drawing
-        self._bbox_cache = ezdxf.bbox.Cache()
-        self._render_context = self._make_render_context(document)
-        self._reset_backend()
-        self._visible_layers = set()
-        self._current_layout = None
+        self._cad.set_document(document, layout=layout)
         self._populate_layouts()
         self._populate_layer_list()
-        self.draw_layout(layout)
         self.setWindowTitle("CAD Viewer - " + str(document.filename))
-
-    def _make_render_context(self, doc) -> RenderContext:
-        def update_layers_state(layers: Sequence[LayerProperties]):
-            if self._visible_layers:
-                set_layers_state(layers, self._visible_layers, state=True)
-
-        render_context = RenderContext(doc)
-        render_context.set_layer_properties_override(update_layers_state)
-        return render_context
 
     def _populate_layer_list(self):
         self.layers.blockSignals(True)
         self.layers.clear()
-        for layer in self._render_context.layers.values():
+        for layer in self._cad.render_context.layers.values():
             name = layer.layer
             item = qw.QListWidgetItem()
             self.layers.addItem(item)
@@ -335,7 +435,7 @@ class CadViewer(qw.QMainWindow):
             return run
 
         self.select_layout_menu.clear()
-        for layout_name in self.doc.layout_names_in_taborder():
+        for layout_name in self._cad.doc.layout_names_in_taborder():
             action = QAction(layout_name, self)
             action.triggered.connect(draw_layout(layout_name))
             self.select_layout_menu.addAction(action)
@@ -346,15 +446,9 @@ class CadViewer(qw.QMainWindow):
         reset_view: bool = True,
     ):
         print(f"drawing {layout_name}")
-        self._current_layout = layout_name
-        self.view.begin_loading()
-        new_scene = qw.QGraphicsScene()
-        self._backend.set_scene(new_scene)
-        layout = self.doc.layout(layout_name)
-        self._update_render_context(layout)
         try:
             start = time.perf_counter()
-            self.create_frontend().draw_layout(layout)
+            self._cad.draw_layout(layout_name, reset_view=reset_view)
             duration = time.perf_counter() - start
             print(f"took {duration:.4f} seconds")
         except DXFStructureError as e:
@@ -363,27 +457,9 @@ class CadViewer(qw.QMainWindow):
                 "DXF Structure Error",
                 f'Abort rendering of layout "{layout_name}": {str(e)}',
             )
-        finally:
-            self._backend.finalize()
-        self.view.end_loading(new_scene)
-        self.view.buffer_scene_rect()
-        if reset_view:
-            self.view.fit_to_scene()
-
-    def create_frontend(self):
-        return Frontend(
-            ctx=self._render_context,
-            out=self._backend,
-            config=self._config,
-            bbox_cache=self._bbox_cache
-        )
-
-    def _update_render_context(self, layout):
-        assert self._render_context is not None
-        self._render_context.set_current_layout(layout)
 
     def resizeEvent(self, event: qg.QResizeEvent) -> None:
-        self.view.fit_to_scene()
+        self._view.fit_to_scene()
 
     def _layer_checkboxes(self) -> Iterable[tuple[int, qw.QCheckBox]]:
         for i in range(self.layers.count()):
@@ -399,11 +475,11 @@ class CadViewer(qw.QMainWindow):
                 item.setCheckState(item_state)
                 item.blockSignals(False)
 
-        self._visible_layers = set()
+        visible_layers = set()
         for i, layer in self._layer_checkboxes():
             if layer.checkState() == qc.Qt.Checked:
-                self._visible_layers.add(layer.text())
-        self.draw_layout(self._current_layout, reset_view=False)
+                visible_layers.add(layer.text())
+        self._cad.set_visible_layers(visible_layers)
 
     @Slot()
     def _toggle_sidebar(self):
@@ -416,7 +492,7 @@ class CadViewer(qw.QMainWindow):
         )
 
     @Slot(object, int)
-    def _on_element_selected(
+    def _on_element_hovered(
         self, elements: list[qw.QGraphicsItem], index: int
     ):
         if not elements:

--- a/src/ezdxf/commands.py
+++ b/src/ezdxf/commands.py
@@ -444,7 +444,7 @@ class View(Command):
         except ImportError as e:
             print(str(e))
             sys.exit(1)
-        from ezdxf.addons.drawing.qtviewer import CadViewer
+        from ezdxf.addons.drawing.qtviewer import CADViewer
         from ezdxf.addons.drawing.config import Configuration
 
         config = Configuration.defaults()
@@ -455,7 +455,7 @@ class View(Command):
         signal.signal(signal.SIGINT, signal.SIG_DFL)  # handle Ctrl+C properly
         app = QtWidgets.QApplication(sys.argv)
         set_app_icon(app)
-        viewer = CadViewer(config=config)
+        viewer = CADViewer.from_config(config)
         filename = args.file
         if filename:
             doc, auditor = load_document(filename)


### PR DESCRIPTION
Prompted by https://github.com/mozman/ezdxf/discussions/878 I had a go at creating a simple example of using the Qt drawing functionality to select an element but found that the code was not organised to make this very easy.

This PR splits out the cad widget functionality from CADViewer into a separate CADWidget class which is more suitable for embedding into other applications or injecting custom functionality (such as selecting elements).

There are also some other minor refactorings:
- renamed some `Cad*` classes to `CAD*` to match the convention elsewhere such as `DXFEntity` instead of `DxfEntity`
- fixed what I think is a typo in the beginner docs
- renamed the `element_selected` signal to `element_hovered` which is more specific