### PR TITLE
Reload and watch

### DIFF
--- a/src/ezdxf/addons/drawing/qtviewer.py
+++ b/src/ezdxf/addons/drawing/qtviewer.py
@@ -119,6 +119,22 @@ class CADGraphicsView(qw.QGraphicsView):
         self.scale(factor, factor)
         self._zoom *= factor
 
+    def save_view(self) -> SavedView:
+        return SavedView(
+            self.transform(),
+            self._default_zoom,
+            self._zoom,
+            self.horizontalScrollBar().value(),
+            self.verticalScrollBar().value(),
+        )
+
+    def restore_view(self, view: SavedView):
+        self.setTransform(view.transform)
+        self._default_zoom = view.default_zoom
+        self._zoom = view.zoom
+        self.horizontalScrollBar().setValue(view.x)
+        self.verticalScrollBar().setValue(view.y)
+
     def drawForeground(self, painter: qg.QPainter, rect: qc.QRectF) -> None:
         if self._is_loading and self._loading_overlay:
             painter.save()
@@ -129,6 +145,17 @@ class CADGraphicsView(qw.QGraphicsView):
             painter.setPen(qc.Qt.white)
             painter.drawText(r.center(), "Loading...")
             painter.restore()
+
+
+class SavedView:
+    def __init__(
+        self, transform: qg.QTransform, default_zoom: float, zoom: float, x: int, y: int
+    ):
+        self.transform = transform
+        self.default_zoom = default_zoom
+        self.zoom = zoom
+        self.x = x
+        self.y = y
 
 
 class CADGraphicsViewWithOverlay(CADGraphicsView):
@@ -233,11 +260,15 @@ class CADWidget(qw.QWidget):
     def render_context(self) -> RenderContext:
         return self._render_context
 
+    @property
+    def current_layout(self) -> str:
+        return self._current_layout
+
     def set_document(
-            self,
-            document: Drawing,
-            *,
-            layout: str = "Model",
+        self,
+        document: Drawing,
+        *,
+        layout: str = "Model",
     ):
         self._doc = document
         # initialize bounding box cache for faste paperspace drawing
@@ -262,9 +293,9 @@ class CADWidget(qw.QWidget):
         return render_context
 
     def draw_layout(
-            self,
-            layout_name: str,
-            reset_view: bool = True,
+        self,
+        layout_name: str,
+        reset_view: bool = True,
     ):
         self._current_layout = layout_name
         self._view.begin_loading()
@@ -286,7 +317,7 @@ class CADWidget(qw.QWidget):
             ctx=self._render_context,
             out=self._backend,
             config=self._config,
-            bbox_cache=self._bbox_cache
+            bbox_cache=self._bbox_cache,
         )
 
     def _update_render_context(self, layout: Layout) -> None:
@@ -298,7 +329,9 @@ class CADViewer(qw.QMainWindow):
     def __init__(self, cad: Optional[CADWidget] = None):
         super().__init__()
         if cad is None:
-            self._cad = CADWidget(CADGraphicsViewWithOverlay(), config=Configuration.defaults())
+            self._cad = CADWidget(
+                CADGraphicsViewWithOverlay(), config=Configuration.defaults()
+            )
         else:
             self._cad = cad
         self._view = self._cad.view
@@ -320,6 +353,11 @@ class CADViewer(qw.QMainWindow):
         toggle_selection_marker_action = QAction("Toggle Entity Marker", self)
         toggle_selection_marker_action.triggered.connect(self._toggle_selection_marker)
         menu.addAction(toggle_selection_marker_action)
+
+        reload_action = QAction("Reload", self)
+        reload_action.setShortcut(qg.QKeySequence("F5"))
+        reload_action.triggered.connect(self._reload)
+        menu.addAction(reload_action)
 
         self.sidebar = qw.QSplitter(qc.Qt.Vertical)
         self.layers = qw.QListWidget()
@@ -360,6 +398,28 @@ class CADViewer(qw.QMainWindow):
         self._view = CADGraphicsViewWithOverlay()
         self._cad = CADWidget(self._view)
 
+    def load_file(self, path: str, layout: str = "Model"):
+        try:
+            if os.path.splitext(path)[1].lower() == ".dwg":
+                doc = odafc.readfile(path)
+                auditor = doc.audit()
+            else:
+                try:
+                    doc = ezdxf.readfile(path)
+                except ezdxf.DXFError:
+                    doc, auditor = recover.readfile(path)
+                else:
+                    auditor = doc.audit()
+            self.set_document(doc, auditor, layout=layout)
+        except IOError as e:
+            qw.QMessageBox.critical(self, "Loading Error", str(e))
+        except DXFStructureError as e:
+            qw.QMessageBox.critical(
+                self,
+                "DXF Structure Error",
+                f'Invalid DXF file "{path}": {str(e)}',
+            )
+
     def _select_doc(self):
         path, _ = qw.QFileDialog.getOpenFileName(
             self,
@@ -367,26 +427,7 @@ class CADViewer(qw.QMainWindow):
             filter="CAD Documents (*.dxf *.DXF *.dwg *.DWG)",
         )
         if path:
-            try:
-                if os.path.splitext(path)[1].lower() == ".dwg":
-                    doc = odafc.readfile(path)
-                    auditor = doc.audit()
-                else:
-                    try:
-                        doc = ezdxf.readfile(path)
-                    except ezdxf.DXFError:
-                        doc, auditor = recover.readfile(path)
-                    else:
-                        auditor = doc.audit()
-                self.set_document(doc, auditor)
-            except IOError as e:
-                qw.QMessageBox.critical(self, "Loading Error", str(e))
-            except DXFStructureError as e:
-                qw.QMessageBox.critical(
-                    self,
-                    "DXF Structure Error",
-                    f'Invalid DXF file "{path}": {str(e)}',
-                )
+            self.load_file(path)
 
     def set_document(
         self,
@@ -492,6 +533,14 @@ class CADViewer(qw.QMainWindow):
     @Slot()
     def _toggle_selection_marker(self):
         self._view.toggle_selection_marker()
+
+    @Slot()
+    def _reload(self):
+        print("reload")
+        if self._cad.doc.filename:
+            view = self._view.save_view()
+            self.load_file(self._cad.doc.filename, layout=self._cad.current_layout)
+            self._view.restore_view(view)
 
     @Slot(qc.QPointF)
     def _on_mouse_moved(self, mouse_pos: qc.QPointF):


### PR DESCRIPTION
adds functionality requested in https://github.com/mozman/ezdxf/discussions/874

adds a 'Reload' menu to the CAD viewer with the following options:
- `Reload (F5)` immediately reloads the current CAD document
- `Keep View` choose whether the view is retained or reset when the document is reloaded
- `Watch` automatically reload if the file changes

I think the watch option might be useful when using ezdxf to generate a file. The viewer can be kept open and will update whenever you re-run your script that generates the file