### PR TITLE
fixed a typo in ezdxf.path.rect()

### DIFF
--- a/src/ezdxf/path/shapes.py
+++ b/src/ezdxf/path/shapes.py
@@ -150,7 +150,7 @@ def rect(
     w2 = float(width) / 2.0
     h2 = float(height) / 2.0
     path = converter.from_vertices(
-        [(w2, h2), (-w2, h2), (-w2, -h2), (w2, h2)], close=True
+        [(w2, h2), (-w2, h2), (-w2, -h2), (w2, -h2)], close=True
     )
     if transform is None:
         return path


### PR DESCRIPTION
There seems to be a missing minus sign in the `ezdxf.path.rect()` function.  As a result, the final vertex is the upper-right corner, not the expected lower-right corner, and you end up with a right triangle instead of the expected rectangle.   I have fixed the problem by adding the missing minus sign.