### PR TITLE
Changed ezdxf.entities.dxfgfx.get_font_name() to correctly handle implicitly-styled Text entities

### DIFF
--- a/src/ezdxf/entities/dxfgfx.py
+++ b/src/ezdxf/entities/dxfgfx.py
@@ -721,7 +721,7 @@ def get_font_name(entity: DXFEntity) -> str:
 
     """
     font_name = "txt"
-    if entity.doc and entity.dxf.hasattr("style"):
+    if entity.doc and entity.dxf.is_supported("style"):
         style_name = entity.dxf.style
         style = entity.doc.styles.get(style_name)
         if style:


### PR DESCRIPTION
Let `msp` be the model space of some dxf document in which the font of the "Standard" text style is "OpenSans-Regular.ttf" (for example), rather than the more usual "txt".  Then, `ezdxf.entities.dxfgfx.get_font_name(msp.add_text("HELLO WORLD))` incorrectly returns "txt".  It ought to return "OpenSans-Regular.ttf".

I think the cleanest fix to this problem is to change the way `ezdxf.entities.dxfgfx.get_font_name()` determines whether entity "has" (in some sense) a style.  We should not use `entity.dxf.hasattr("style")`, which will return False if entity happens to be an ezdxf.entities.text.Text object that has not had its style explicitly set.  Instead, we should use  `entity.dxf.is_supported("style")`, which will return true for  an implicitly-Standard-style Text object.  The program flow within the get_font_name() function will then proceed correctly.