### PR TITLE
Fix a bug in intersect_circle

### DIFF
--- a/src/ezdxf/math/circle.py
+++ b/src/ezdxf/math/circle.py
@@ -227,10 +227,12 @@ class ConstructionCircle:
         if d_min <= d <= d_max:
             angle = (other.center - self.center).angle
             # Circles touches at one point:
-            if math.isclose(d, d_max, abs_tol=abs_tol) or math.isclose(
-                d, d_min, abs_tol=abs_tol
-            ):
+            if math.isclose(d, d_max, abs_tol=abs_tol):
                 return (self.point_at(angle),)
+            if math.isclose(d, d_min, abs_tol=abs_tol):
+                if r1 >= r2:
+                    return (self.point_at(angle),)
+                return (self.point_at(angle + math.pi),)
             else:  # Circles intersect in two points:
                 # Law of Cosines:
                 alpha = math.acos((r2 * r2 - r1 * r1 - d * d) / (-2.0 * r1 * d))


### PR DESCRIPTION
When two circles C1 and C2 are tangent internally and r1 < r2, the intersection point is in the opposite direction of O1O2.
![demo](https://github.com/mozman/ezdxf/assets/152783907/55bb56f8-dced-46b6-a826-c4ef6291f011)
