### PR TITLE
Revert "Correct attribute name: landing_gap_size"

### DIFF
--- a/docs/source/dxfobjects/mleaderstyle.rst
+++ b/docs/source/dxfobjects/mleaderstyle.rst
@@ -134,7 +134,7 @@ Factory function         :meth:`ezdxf.document.Drawing.mleader_styles.new`
 
         default is 0
 
-    .. attribute:: dxf.landing_gap_size
+    .. attribute:: dxf.landing_gap
 
         default landing gap size, default is 2.0
 


### PR DESCRIPTION
Reverts mozman/ezdxf#994