### PR TITLE
Fix ClippingShape.is_completely_{inside,outside} spelling

### DIFF
--- a/src/ezdxf/tools/clipping_portal.py
+++ b/src/ezdxf/tools/clipping_portal.py
@@ -69,12 +69,12 @@ class ClippingShape(abc.ABC):
     def bbox(self) -> BoundingBox2d: ...
 
     @abc.abstractmethod
-    def is_completley_inside(self, other: BoundingBox2d) -> bool: ...
+    def is_completely_inside(self, other: BoundingBox2d) -> bool: ...
 
     # returning False means: I don't know!
 
     @abc.abstractmethod
-    def is_completley_outside(self, other: BoundingBox2d) -> bool: ...
+    def is_completely_outside(self, other: BoundingBox2d) -> bool: ...
 
     @abc.abstractmethod
     def clip_point(self, point: Vec2) -> Optional[Vec2]: ...
@@ -248,9 +248,9 @@ class ClippingPolygon(ClippingShape):
     def clip_polyline(self, points: NumpyPoints2d) -> Sequence[NumpyPoints2d]:
         clipper = self.clipper
         polyline_bbox = BoundingBox2d(points.extents())
-        if self.is_completley_outside(polyline_bbox):
+        if self.is_completely_outside(polyline_bbox):
             return tuple()
-        if self.is_completley_inside(polyline_bbox):
+        if self.is_completely_inside(polyline_bbox):
             return (points,)
         return [
             NumpyPoints2d(part)
@@ -261,9 +261,9 @@ class ClippingPolygon(ClippingShape):
     def clip_polygon(self, points: NumpyPoints2d) -> Sequence[NumpyPoints2d]:
         clipper = self.clipper
         polygon_bbox = BoundingBox2d(points.extents())
-        if self.is_completley_outside(polygon_bbox):
+        if self.is_completely_outside(polygon_bbox):
             return tuple()
-        if self.is_completley_inside(polygon_bbox):
+        if self.is_completely_inside(polygon_bbox):
             return (points,)
         return [
             NumpyPoints2d(part)
@@ -278,10 +278,10 @@ class ClippingPolygon(ClippingShape):
         for path in paths:
             for sub_path in path.sub_paths():
                 path_bbox = BoundingBox2d(sub_path.control_vertices())
-                if self.is_completley_inside(path_bbox):
+                if self.is_completely_inside(path_bbox):
                     yield sub_path
                     continue
-                if self.is_completley_outside(path_bbox):
+                if self.is_completely_outside(path_bbox):
                     continue
                 polyline = Vec2.list(sub_path.flattening(max_sagitta, segments=4))
                 for part in clipper.clip_polyline(polyline):
@@ -297,10 +297,10 @@ class ClippingPolygon(ClippingShape):
                 if len(sub_path) < 2:
                     continue
                 path_bbox = BoundingBox2d(sub_path.control_vertices())
-                if self.is_completley_inside(path_bbox):
+                if self.is_completely_inside(path_bbox):
                     yield sub_path
                     continue
-                if self.is_completley_outside(path_bbox):
+                if self.is_completely_outside(path_bbox):
                     continue
                 for part in clipper.clip_polygon(
                     Vec2.list(sub_path.flattening(max_sagitta, segments=4))
@@ -328,10 +328,10 @@ class ClippingRect(ClippingPolygon):
 
         super().__init__(bbox, ClippingRect2d(bbox.extmin, bbox.extmax))
 
-    def is_completley_inside(self, other: BoundingBox2d) -> bool:
+    def is_completely_inside(self, other: BoundingBox2d) -> bool:
         return self._bbox.contains(other)
 
-    def is_completley_outside(self, other: BoundingBox2d) -> bool:
+    def is_completely_outside(self, other: BoundingBox2d) -> bool:
         return not self._bbox.has_intersection(other)
 
     def clip_point(self, point: Vec2) -> Optional[Vec2]:
@@ -381,10 +381,10 @@ class ConvexClippingPolygon(ClippingPolygon):
         polygon = Vec2.list(vertices)
         super().__init__(BoundingBox2d(polygon), ConvexClippingPolygon2d(polygon))
 
-    def is_completley_inside(self, other: BoundingBox2d) -> bool:
+    def is_completely_inside(self, other: BoundingBox2d) -> bool:
         return False  # I don't know!
 
-    def is_completley_outside(self, other: BoundingBox2d) -> bool:
+    def is_completely_outside(self, other: BoundingBox2d) -> bool:
         return not self._bbox.has_intersection(other)
 
 
@@ -400,10 +400,10 @@ class ConcaveClippingPolygon(ClippingPolygon):
         polygon = Vec2.list(vertices)
         super().__init__(BoundingBox2d(polygon), ConcaveClippingPolygon2d(polygon))
 
-    def is_completley_inside(self, other: BoundingBox2d) -> bool:
+    def is_completely_inside(self, other: BoundingBox2d) -> bool:
         return False  # I don't know!
 
-    def is_completley_outside(self, other: BoundingBox2d) -> bool:
+    def is_completely_outside(self, other: BoundingBox2d) -> bool:
         return not self._bbox.has_intersection(other)
 
 
@@ -419,11 +419,11 @@ class InvertedClippingPolygon(ClippingPolygon):
         polygon = Vec2.list(vertices)
         super().__init__(outer_bounds, InvertedClippingPolygon2d(polygon, outer_bounds))
 
-    def is_completley_inside(self, other: BoundingBox2d) -> bool:
+    def is_completely_inside(self, other: BoundingBox2d) -> bool:
         # returning False means: I don't know!
         return False  # not easy to detect
 
-    def is_completley_outside(self, other: BoundingBox2d) -> bool:
+    def is_completely_outside(self, other: BoundingBox2d) -> bool:
         return not self._bbox.has_intersection(other)
 
 


### PR DESCRIPTION
Fixes a typo in the names of the `ClippingShape.is_completley_inside` and `ClippingShape.is_completley_outside` methods: “`completley`” should be “`completely`.”