### PR TITLE
Filter out None element from vertices for clipping_polygon

### DIFF
--- a/src/ezdxf/math/clipping.py
+++ b/src/ezdxf/math/clipping.py
@@ -126,14 +126,15 @@ class ConvexClippingPolygon2d:
         """Returns the parts of the clipped polygon. A polygon is a closed polyline."""
 
         def is_inside(point: Vec2) -> bool:
-            # is point left of line:
+            # is point left of line (0.0 is used as tolerance for the check):
             return (clip_end.x - clip_start.x) * (point.y - clip_start.y) - (
                 clip_end.y - clip_start.y
             ) * (point.x - clip_start.x) > 0.0
 
         def edge_intersection() -> Vec2:
+            # use consistent tolerance for `is_inside()` and `edge_intersection()`
             return intersection_line_line_2d(
-                (edge_start, edge_end), (clip_start, clip_end)
+                (edge_start, edge_end), (clip_start, clip_end), abs_tol=0.0
             )
 
         # The clipping polygon is always treated as a closed polyline!


### PR DESCRIPTION

Dear @mozman , could you please review this minor merge request?

During viewport drawing in `paperspace`, the `None` element from `clipped.copy()` is raising errors for later processing, thus filtering them out to avoid the errors.

It produces same rendering results as compared to autodesk online viewer at https://viewer.autodesk.com/



Could you please review and see if this is a safe filtering and can be merged?