### PR TITLE
Removed superfluous "Optional" in odafc.readfile

### DIFF
--- a/src/ezdxf/addons/odafc.py
+++ b/src/ezdxf/addons/odafc.py
@@ -109,7 +109,7 @@ def map_version(version: str) -> str:
 
 def readfile(
     filename: str | os.PathLike, version: Optional[str] = None, *, audit: bool = False
-) -> Optional[Drawing]:
+) -> Drawing:
     """Uses an installed `ODA File Converter`_ to convert a DWG/DXB/DXF file
     into a temporary DXF file and load this file by `ezdxf`.
 


### PR DESCRIPTION
This pull request removes the `Optional` from the return type annotation of the `ezdxf.addons.odafc.readfile` function, as `None` is never returned from the function.

PS: This project is awesome, thank you for your work!