### PR TITLE
Fix units.unit_name to work on Python 3.11 or later

### DIFF
--- a/src/ezdxf/units.py
+++ b/src/ezdxf/units.py
@@ -202,7 +202,7 @@ def unit_name(enum: int) -> str:
     """Returns the name of the unit enum."""
     try:
         return InsertUnits(enum).name
-    except (ValueError, IndexError):
+    except ValueError:
         return "unitless"
 
 

--- a/src/ezdxf/units.py
+++ b/src/ezdxf/units.py
@@ -201,7 +201,7 @@ def conversion_factor(
 def unit_name(enum: int) -> str:
     """Returns the name of the unit enum."""
     try:
-        return str(InsertUnits(enum)).split(".")[1]
+        return InsertUnits(enum).name
     except (ValueError, IndexError):
         return "unitless"
 

--- a/tests/test_05_tools/test_500_units.py
+++ b/tests/test_05_tools/test_500_units.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019-2020 Manfred Moitzi
 # License: MIT License
 import pytest
-from ezdxf.units import DrawingUnits, PaperSpaceUnits, conversion_factor
+from ezdxf.units import DrawingUnits, PaperSpaceUnits, conversion_factor, unit_name
 from math import isclose
 
 
@@ -159,3 +159,12 @@ def test_conversion_type_error(source, target):
 def test_conversion_invalid_units():
     with pytest.raises(ValueError):
         conversion_factor(25, 6)
+
+
+def test_unit_name_valid_input():
+    assert unit_name(0) == "Unitless"
+    assert unit_name(1) == "Inches"
+
+
+def test_unit_name_invalid_input():
+    assert unit_name(-1) == "unitless"


### PR DESCRIPTION
fix #1131 