### PR TITLE
Optional content groups in muPDF backend

### DIFF
--- a/src/ezdxf/addons/drawing/frontend.py
+++ b/src/ezdxf/addons/drawing/frontend.py
@@ -133,7 +133,7 @@ class UniversalFrontend:
         # RenderContext contains all information to resolve resources for a
         # specific DXF document.
         self.ctx = ctx
-        
+
         # the render pipeline is the connection between frontend and backend
         self.pipeline = pipeline
         pipeline.set_draw_entities_callback(self.draw_entities_callback)
@@ -227,8 +227,8 @@ class UniversalFrontend:
 
         .. versionchanged:: 1.3.0
 
-            This method is the first function in the stack of new property override 
-            functions.  It is possible to push additional override functions onto this 
+            This method is the first function in the stack of new property override
+            functions.  It is possible to push additional override functions onto this
             stack, see also :meth:`push_property_override_function`.
 
         """
@@ -241,7 +241,7 @@ class UniversalFrontend:
         function, because the DXF entities are not copies - except for virtual entities.
 
         The override functions are called after resolving the DXF attributes of an entity
-        and before the :meth:`Frontend.draw_entity` method in the order from first to 
+        and before the :meth:`Frontend.draw_entity` method in the order from first to
         last.
 
         .. versionadded:: 1.3.0
@@ -566,8 +566,9 @@ class UniversalFrontend:
                 line_pattern = baseline.pattern_renderer(line.distance)
                 for s, e in line_pattern.render(line.start, line.end):
                     if ocs.transform:
-                        s, e = ocs.to_wcs((s.x, s.y, elevation)), ocs.to_wcs(
-                            (e.x, e.y, elevation)
+                        s, e = (
+                            ocs.to_wcs((s.x, s.y, elevation)),
+                            ocs.to_wcs((e.x, e.y, elevation)),
                         )
                     lines.append((s, e))
         self.pipeline.draw_solid_lines(lines, properties)
@@ -750,7 +751,8 @@ class UniversalFrontend:
 
                 if image.transparency != 0.0:
                     loaded_image = _multiply_alpha(
-                        loaded_image, 1.0 - image.transparency  # type: ignore
+                        loaded_image,
+                        1.0 - image.transparency,  # type: ignore
                     )
                 image_data = ImageData(
                     image=np.array(loaded_image),

--- a/src/ezdxf/addons/drawing/layout.py
+++ b/src/ezdxf/addons/drawing/layout.py
@@ -298,6 +298,7 @@ class Settings:
             e.g. 0.15 is 15% of :attr:`max_stroke_width`
         output_coordinate_space: expert feature to map the DXF coordinates to the
             output coordinate system [0, output_coordinate_space]
+        output_layers: For supported backends, separate the entities into 'layers' in the output
 
     """
 
@@ -321,6 +322,7 @@ class Settings:
     # dimension - aspect ratio is always preserved - these are CAD drawings!
     # The SVGBackend uses this feature to map all coordinates to integer values:
     output_coordinate_space: float = 1_000_000  # e.g. for SVGBackend
+    output_layers: bool = True
 
     def __post_init__(self) -> None:
         if self.content_rotation not in (0, 90, 180, 270):

--- a/src/ezdxf/addons/drawing/properties.py
+++ b/src/ezdxf/addons/drawing/properties.py
@@ -302,16 +302,16 @@ LayerPropsOverride = Callable[[Sequence[LayerProperties]], None]
 
 
 class RenderContext:
-    """The render context for the given DXF document. The :class:`RenderContext` 
-    resolves the properties of DXF entities from the context they reside in to actual 
+    """The render context for the given DXF document. The :class:`RenderContext`
+    resolves the properties of DXF entities from the context they reside in to actual
     values like RGB colors, transparency, linewidth and so on.
 
-    A given `ctb` file (plot style file) overrides the default properties for all 
+    A given `ctb` file (plot style file) overrides the default properties for all
     layouts, which means the plot style table stored in the layout is always ignored.
 
     Args:
         doc: DXF document
-        ctb: path to a plot style table or a :class:`~ezdxf.addons.acadctb.ColorDependentPlotStyles` 
+        ctb: path to a plot style table or a :class:`~ezdxf.addons.acadctb.ColorDependentPlotStyles`
             instance
         export_mode: Whether to render the document as it would look when
             exported (plotted) by a CAD application to a file such as pdf,
@@ -389,10 +389,10 @@ class RenderContext:
 
     def set_current_layout(self, layout: Layout, ctb: str | CTB = ""):
         """Set the current layout and update layout specific properties.
-        
+
         Args:
             layout: modelspace or a paperspace layout
-            ctb: path to a plot style table or a :class:`~ezdxf.addons.acadctb.ColorDependentPlotStyles` 
+            ctb: path to a plot style table or a :class:`~ezdxf.addons.acadctb.ColorDependentPlotStyles`
                 instance
 
         """
@@ -405,7 +405,9 @@ class RenderContext:
                 # last is the ctb stored in the layout
                 ctb = layout.get_plot_style_filename()
         elif not isinstance(ctb, CTB):
-            raise TypeError(f"expected argument ctb of type str or {CTB.__name__}, got {type(ctb)}")
+            raise TypeError(
+                f"expected argument ctb of type str or {CTB.__name__}, got {type(ctb)}"
+            )
         self.current_layout_properties = LayoutProperties.from_layout(layout)
         self.plot_styles = self._load_plot_style_table(ctb)
         self.layers = dict()


### PR DESCRIPTION
This PR introduces the option for the muPDF backend to tag entities as belonging to 'optional content groups' which are similar to layers in that visibility of entities in the groups can be toggled in supported viewers. [muPDF OCG documentation](https://pymupdf.readthedocs.io/en/latest/recipes-optional-content.html). This feature was requested in #1154 .

The current implementation only outputs visible layers as entities on invisible/hidden layers are filtered out by the frontend. A future improvement could be to use `--all-layers-visible` together with an option for the backend to set the layer visibility in the output independently from their visibility in the dxf.

Some fixes have also been applied to the `ezdxf draw` command as the `--all-layers-visible` had stopped working.