### PR TITLE
add native text rendering to muPDF backend

### DIFF
--- a/src/ezdxf/addons/drawing/backend.py
+++ b/src/ezdxf/addons/drawing/backend.py
@@ -12,7 +12,9 @@ from ezdxf.addons.drawing.config import Configuration
 from ezdxf.addons.drawing.properties import Properties, BackendProperties
 from ezdxf.addons.drawing.type_hints import Color
 from ezdxf.entities import DXFGraphic
+from ezdxf.fonts.fonts import AbstractFont
 from ezdxf.math import Vec2, Matrix44
+from ezdxf.math.bbox import BoundingBox2d
 from ezdxf.npshapes import NumpyPath2d, NumpyPoints2d, single_paths
 
 BkPath2d: TypeAlias = NumpyPath2d
@@ -116,6 +118,20 @@ class BackendInterface(ABC):
     @abstractmethod
     def draw_image(self, image_data: ImageData, properties: BackendProperties) -> None:
         raise NotImplementedError
+
+    def draw_text(
+        self,
+        text: str,
+        bbox: BoundingBox2d,
+        transform: Matrix44,
+        properties: BackendProperties,
+        font: AbstractFont,
+        cap_height: float,
+    ) -> None:
+        """Handle rendering of text with `TextPolicy.NATIVE`. If the backend does not support
+        text data then this method can do nothing.
+        """
+        pass
 
     @abstractmethod
     def clear(self) -> None:

--- a/src/ezdxf/addons/drawing/config.py
+++ b/src/ezdxf/addons/drawing/config.py
@@ -154,6 +154,8 @@ class TextPolicy(Enum):
         OUTLINE: text is rendered as outline paths
         REPLACE_RECT: replace text by a rectangle
         REPLACE_FILL: replace text by a filled rectangle
+        NATIVE: for supported backends, output as text instead of rendering to shapes.
+            For unsupported backends, text will be ignored.
         IGNORE: ignore text entirely
 
     """
@@ -162,6 +164,7 @@ class TextPolicy(Enum):
     OUTLINE = auto()
     REPLACE_RECT = auto()
     REPLACE_FILL = auto()
+    NATIVE = auto()
     IGNORE = auto()
 
 

--- a/src/ezdxf/fonts/font_manager.py
+++ b/src/ezdxf/fonts/font_manager.py
@@ -362,6 +362,10 @@ class FontManager:
         self._loaded_lff_glyph_caches[font_name] = glyph_cache
         return glyph_cache
 
+    def get_font_path(self, font_name: str) -> Path:
+        cache_entry = self._font_cache.get(font_name, self.fallback_font_name())
+        return cache_entry.file_path
+
     def get_font_face(self, font_name: str) -> FontFace:
         cache_entry = self._font_cache.get(font_name, self.fallback_font_name())
         return cache_entry.font_face


### PR DESCRIPTION
This is an investigation into the feasibility of rendering text to PDF in a way that a viewer application is able to understand the text information (i.e. be able to select and copy the text). This was requested in https://github.com/mozman/ezdxf/discussions/1158 .

This PR introduces the `TextPolicy.NATIVE` setting to pass text information directly to the backend rather than 'baking' it to a series of glyph shapes since this looses the original text information.

If the backend supports text it can implement the `draw_text` method which gets called when `TextPolicy.NATIVE` is used. The PDF backend supports loading fonts and rendering text with arbitrary 2D transformations defined by a matrix.

The current implementation relies on a magic number to scale the font size correctly to match the baked text from the frontend (which I am treating as ground truth). For the files I have access to the value of 1.375 results in almost identical text however other fonts may require a different scale factor to get exact results.

In the following screenshot white is baked text and red is 'native' PDF text
![image](https://github.com/user-attachments/assets/8cec9e98-3922-4a26-895c-97f6223c34d3)
