### PR TITLE
Fix mline.py crash due to passing int instead of float

### DIFF
--- a/src/ezdxf/render/mline.py
+++ b/src/ezdxf/render/mline.py
@@ -39,7 +39,7 @@ def virtual_entities(mline: MLine) -> list[DXFGraphic]:
         attribs = _dxfattribs(mline)
         attribs["color"] = style.dxf.fill_color
         attribs["elevation"] = Vec3(ocs.from_wcs(bottom_border[0])).replace(
-            x=0, y=0
+            x=0.0, y=0.0
         )
         attribs["extrusion"] = mline.dxf.extrusion
         hatch = cast("Hatch", factory.new("HATCH", dxfattribs=attribs, doc=doc))


### PR DESCRIPTION
Based on [this bug report](https://github.com/mozman/ezdxf/issues/1167). I think this is a pretty trivial fix, but if I'm mistaken please do let me know!