### PR TITLE
Insert.add_auto_attribs() support default values

### DIFF
--- a/src/ezdxf/entities/insert.py
+++ b/src/ezdxf/entities/insert.py
@@ -721,7 +721,9 @@ class Insert(LinkedEntities):
 
         def unpack(dxfattribs) -> tuple[str, str, UVec]:
             tag = dxfattribs.pop("tag")
-            text = values.get(tag, "")
+            text = values.get(tag, None)
+            if text is None:  # get default value
+                text = dxfattribs.pop("text")
             location = dxfattribs.pop("insert")
             return tag, text, location
 


### PR DESCRIPTION
It is probably intuitive to assign a default value from the block (attribute) definition.