### PR TITLE
add support for pickling DXF entities

### DIFF
--- a/src/ezdxf/entities/dxfns.py
+++ b/src/ezdxf/entities/dxfns.py
@@ -86,6 +86,15 @@ class DXFNamespace:
     def __deepcopy__(self, memodict: Optional[dict] = None):
         return self.copy(self._entity)
 
+    def __getstate__(self) -> object:
+        return self.__dict__
+
+    def __setstate__(self, state: object) -> None:
+        if not isinstance(state, dict):
+            raise TypeError(f"invalid state: {type(state).__name__}")
+        # bypass __setattr__
+        object.__setattr__(self, "__dict__", state)
+
     def reset_handles(self):
         """Reset handle and owner to None."""
         self.__dict__["handle"] = None

--- a/tests/test_10_issues/test_issue_1231_pickling.py
+++ b/tests/test_10_issues/test_issue_1231_pickling.py
@@ -1,0 +1,36 @@
+import io
+import pickle
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import ezdxf
+from ezdxf.document import Drawing
+
+EXAMPLES = Path(__file__).parent.parent.parent / "examples_dxf"
+
+
+def example_dxfs() -> Iterator[Path]:
+    for item in EXAMPLES.iterdir():
+        if item.suffix.lower() == ".dxf":
+            yield item
+
+
+def _to_dxf_str(doc: Drawing) -> str:
+    stream = io.StringIO()
+    doc.write(stream)
+    return stream.getvalue()
+
+
+def test_document_pickle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ezdxf.options, "write_fixed_meta_data_for_testing", True)
+
+    for item in example_dxfs():
+        print(f"testing pickling of {item}")
+
+        doc = ezdxf.readfile(item)
+        doc_serialized = pickle.dumps(doc)
+        doc_loaded = pickle.loads(doc_serialized)
+
+        assert _to_dxf_str(doc) == _to_dxf_str(doc_loaded)


### PR DESCRIPTION
fixes https://github.com/mozman/ezdxf/issues/1231

`DXFNamespace` has custom `__getattr__` and `__setattr__` so the default pickling mechanism doesn't work. Instead, custom state management is implemented for `DXFNamespace`. The unit test attempts to pickle and unpickle every example dxf. On my machine this takes ~3 seconds.

Pickling may be useful to cache parse results or to send dxf documents to subprocesses in a multiprocessed application.