### PR TITLE
docs: Fix vport docs

### DIFF
--- a/docs/source/tables/vport_table_entry.rst
+++ b/docs/source/tables/vport_table_entry.rst
@@ -73,7 +73,7 @@ Factory function         :meth:`Drawing.viewports.new`
 
         View direction from target point (in :ref:`WCS`)
 
-    .. attribute:: dxf.target_point
+    .. attribute:: dxf.target
 
         View target point (in :ref:`WCS`)
 

--- a/docs/source/tables/vport_table_entry.rst
+++ b/docs/source/tables/vport_table_entry.rst
@@ -69,7 +69,7 @@ Factory function         :meth:`Drawing.viewports.new`
 
         Grid spacing X and Y
 
-    .. attribute:: dxf.direction_point
+    .. attribute:: dxf.direction
 
         View direction from target point (in :ref:`WCS`)
 


### PR DESCRIPTION
This updates the docs to align with the attributes of the `VPort` entity used in code

https://github.com/mozman/ezdxf/blob/c1b01ca4b7baccb7751da23c4a1be2dfb5d9a35d/src/ezdxf/entities/vport.py#L44-L51