### PR TITLE
Fix MultiLineString in GeoProxy

### DIFF
--- a/integration_tests/test_geo.py
+++ b/integration_tests/test_geo.py
@@ -61,5 +61,21 @@ def test_valid_hatch():
     assert p.root != {}
 
 
+def test_proxy_given_hatch_when_force_line_string_generates_valid_multi_line_string() -> None:
+    hatch = factory.new("HATCH")
+    paths = hatch.paths
+    paths.add_polyline_path(square(10), flags=const.BOUNDARY_PATH_EXTERNAL)
+    paths.add_polyline_path(
+        translate(square(3), (1, 1)), flags=const.BOUNDARY_PATH_DEFAULT
+    )
+    p = geo.proxy(hatch, force_line_string=True)
+    feature = p.__geo_interface__
+    assert feature["type"] == "MultiLineString"
+
+    # According to the __geo_interface__ specification:
+    # https://gist.github.com/sgillies/2217756
+    assert isinstance(feature["coordinates"][0][0], tuple)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/src/ezdxf/addons/geo.py
+++ b/src/ezdxf/addons/geo.py
@@ -695,6 +695,7 @@ def _rebuild(geo_mapping: GeoMapping, places: int = 6) -> GeoMapping:
         coordinates = []
         for line in geo_interface[COORDINATES]:
             coordinates.append([pnt(v) for v in line])
+        geo_interface[COORDINATES] = coordinates
     elif type_ == POLYGON:
         geo_interface[COORDINATES] = _polygon(*geo_interface[COORDINATES])
     elif type_ == MULTI_POLYGON:


### PR DESCRIPTION
## Description

This pull request fixes a bug in `ezdxf.addons.geo` where the conversion to `MultiLineString` does not completely behave as expected: the coordinates in the resulting geometry are `Vec3` instances instead of simple `tuple`s, as indicated by the [`__geo_interface__`](https://gist.github.com/sgillies/2217756#__geo_interface__) specification.

This does not bother *shapely*, but some other libraries that support the `__geo_interface__` fail to parse the resulting geometry, like [geojson](https://github.com/jazzband/geojson) for example. 

## Environment used to reproduce

- OS: Windows 10
- Python 3.12
- _ezdxf_ 1.4.0