### PR TITLE
suggested bug fix for 1286

### DIFF
--- a/src/ezdxf/proxygraphic.py
+++ b/src/ezdxf/proxygraphic.py
@@ -315,11 +315,14 @@ class ProxyGraphic:
         index = self._index
         buffer = self._buffer
         while index < len(buffer):
-            size, type_ = struct.unpack_from("<2L", self._buffer, offset=index)
+            size, type_ = struct.unpack_from("<2L", buffer, offset=index)
             try:
                 name = ProxyGraphicTypes(type_).name.lower()
             except ValueError:
                 logger.debug(f"Unsupported Type Code: {type_}")
+                if size == 0:
+                    logger.debug(f"Failed Reading Buffer")
+                    size = len(buffer) - index #jumping to end of buffer
                 index += size
                 continue
             method = getattr(self, name, None)


### PR DESCRIPTION
adding an edge case of jumping to end of buffer when buffer is failed to be read/unpacked.
i am unsure of where/if to add an unit test for the bug.
another possible solution is to instead of jump to end of buffer to jump a small increment such as 8.