### PR TITLE
fixing devision by 0 and improving cache call

### DIFF
--- a/src/ezdxf/addons/drawing/frontend.py
+++ b/src/ezdxf/addons/drawing/frontend.py
@@ -766,27 +766,28 @@ class UniversalFrontend:
             elif show_filename_if_missing:
                 default_cap_height = 20
                 text = image_def.dxf.filename
-                font = self.pipeline.text_engine.get_font(
-                    self.get_font_face(properties)
-                )
-                text_width = font.text_width_ex(text, default_cap_height)
-                image_size = image.dxf.image_size
-                desired_width = image_size.x * 0.75
-                scale = desired_width / text_width
-                translate = Matrix44.translate(
-                    (image_size.x - desired_width) / 2,
-                    (image_size.y - default_cap_height * scale) / 2,
-                    0,
-                )
-                transform = (
-                    Matrix44.scale(scale) @ translate @ image.get_wcs_transform()
-                )
-                self.pipeline.draw_text(
-                    text,
-                    transform,
-                    properties,
-                    default_cap_height,
-                )
+                if text.strip():
+                    font = self.pipeline.text_engine.get_font(
+                        self.get_font_face(properties)
+                    )
+                    text_width = font.text_width_ex(text, default_cap_height)
+                    image_size = image.dxf.image_size
+                    desired_width = image_size.x * 0.75
+                    scale = desired_width / text_width
+                    translate = Matrix44.translate(
+                        (image_size.x - desired_width) / 2,
+                        (image_size.y - default_cap_height * scale) / 2,
+                        0,
+                    )
+                    transform = (
+                        Matrix44.scale(scale) @ translate @ image.get_wcs_transform()
+                    )
+                    self.pipeline.draw_text(
+                        text,
+                        transform,
+                        properties,
+                        default_cap_height,
+                    )
 
             points = [v.vec2 for v in image.boundary_path_wcs()]
             self.pipeline.draw_solid_lines(list(zip(points, points[1:])), properties)

--- a/src/ezdxf/fonts/ttfonts.py
+++ b/src/ezdxf/fonts/ttfonts.py
@@ -138,15 +138,14 @@ class TTFontRenderer(Glyphs):
 
     def get_glyph_width(self, char: str) -> float:
         """Returns the raw glyph width, without any scaling applied."""
-        try:
-            return self._glyph_width_cache[char]
-        except KeyError:
-            pass
-        width = 0.0
-        try:
-            width = self.get_generic_glyph(char).width
-        except KeyError:
-            pass
+        width = self._glyph_width_cache.get(char , 0.0)
+        if width:
+            return width
+        glyph = self._glyph_width_cache.get(char,None)
+        if glyph:
+            width = width.width
+        else:
+            width = 0.0
         self._glyph_width_cache[char] = width
         return width
 


### PR DESCRIPTION
fixxed issue where incase of whitespace file name devision by 0 would occuer see issue #1313.
now when a file name is whitespace no text would be rendered.
also it may be better to use .get() instead of try/catch in ttfonts as try/catch are usualy not ideal.