### PR TITLE
Add support for elevations in GeoProxy.__geo_interface__

### DIFF
--- a/src/ezdxf/addons/geo.py
+++ b/src/ezdxf/addons/geo.py
@@ -669,15 +669,23 @@ def _rebuild(geo_mapping: GeoMapping, places: int = 6) -> GeoMapping:
 
     """
 
-    def pnt(v: Vec3) -> tuple[float, float] | tuple[float, float, float]:
-        if v.z:
-            return round(v.x, places), round(v.y, places), round(v.z, places)
+    def pnt(v: Vec3) -> tuple[float, float]:
         return round(v.x, places), round(v.y, places)
+
+    def pnt_3d(v: Vec3) -> tuple[float, float, float]:
+        return round(v.x, places), round(v.y, places), round(v.z, places)
+
+    def _build_coords(
+        coords: Sequence[Vec3],
+    ) -> list[tuple[float, float] | tuple[float, float, float]]:
+        if any(v.z for v in coords):
+            return [pnt_3d(v) for v in coords]
+        return [pnt(v) for v in coords]
 
     def _polygon(exterior, holes):
         # For type "Polygon", the "coordinates" member MUST be an array of
         # linear ring coordinate arrays.
-        return [[pnt(v) for v in ring] for ring in [exterior] + holes]
+        return [_build_coords(ring) for ring in [exterior] + holes]
 
     geo_interface = dict(geo_mapping)
     type_ = geo_interface[TYPE]
@@ -689,14 +697,14 @@ def _rebuild(geo_mapping: GeoMapping, places: int = 6) -> GeoMapping:
         geo_interface[GEOMETRY] = _rebuild(geo_interface[GEOMETRY])
     elif type_ == POINT:
         v = geo_interface[COORDINATES]
-        geo_interface[COORDINATES] = pnt(v)
+        geo_interface[COORDINATES] = pnt_3d(v) if v.z else pnt(v)
     elif type_ in (LINE_STRING, MULTI_POINT):
         coordinates = geo_interface[COORDINATES]
-        geo_interface[COORDINATES] = [pnt(v) for v in coordinates]
+        geo_interface[COORDINATES] = _build_coords(coordinates)
     elif type_ == MULTI_LINE_STRING:
         coordinates = []
         for line in geo_interface[COORDINATES]:
-            coordinates.append([pnt(v) for v in line])
+            coordinates.append(_build_coords(line))
         geo_interface[COORDINATES] = coordinates
     elif type_ == POLYGON:
         geo_interface[COORDINATES] = _polygon(*geo_interface[COORDINATES])

--- a/src/ezdxf/addons/geo.py
+++ b/src/ezdxf/addons/geo.py
@@ -669,7 +669,9 @@ def _rebuild(geo_mapping: GeoMapping, places: int = 6) -> GeoMapping:
 
     """
 
-    def pnt(v: Vec3) -> tuple[float, float]:
+    def pnt(v: Vec3) -> tuple[float, float] | tuple[float, float, float]:
+        if v.z:
+            return round(v.x, places), round(v.y, places), round(v.z, places)
         return round(v.x, places), round(v.y, places)
 
     def _polygon(exterior, holes):

--- a/tests/test_08_addons/test_813_geo_interface.py
+++ b/tests/test_08_addons/test_813_geo_interface.py
@@ -318,6 +318,43 @@ def test_geo_interface_builder(entity):
     assert geo.GeoProxy.parse(entity).__geo_interface__ == entity
 
 
+@pytest.mark.parametrize(
+    "entity, expected_coords",
+    [
+        (
+            {"type": "MultiPoint", "coordinates": [(0, 0), (0, 1, 1)]},
+            [(0, 0, 0), (0, 1, 1)],
+        ),
+        (
+            {"type": "LineString", "coordinates": [(0, 0), (0, 1, 1)]},
+            [(0, 0, 0), (0, 1, 1)],
+        ),
+        (
+            {"type": "MultiLineString", "coordinates": [[(0, 0), (0, 1, 1)]]},
+            [[(0, 0, 0), (0, 1, 1)]],
+        ),
+        (
+            {"type": "Polygon", "coordinates": [[(0, 0), (0, 1, 1)]]},
+            [[(0, 0, 0), (0, 1, 1)]],
+        ),
+        (
+            {"type": "MultiPolygon", "coordinates": [[[(0, 0), (0, 1, 1)]]]},
+            [[[(0, 0, 0), (0, 1, 1)]]],
+        ),
+    ],
+)
+def test_geo_interface_builder_given_heterogeneous_z_returns_3d_geometry(
+    entity, expected_coords
+) -> None:
+    """This test verifies that if a geometry contains at least one non-zero Z component,
+    it is processed as a 3D geometry. The Z components that were not specified are
+    set to 0.
+    """
+    assert (
+        geo.GeoProxy.parse(entity).__geo_interface__["coordinates"] == expected_coords
+    )
+
+
 def test_point_to_dxf_entity():
     point = list(geo.dxf_entities(POINT))[0]
     assert point.dxftype() == "POINT"

--- a/tests/test_08_addons/test_813_geo_interface.py
+++ b/tests/test_08_addons/test_813_geo_interface.py
@@ -17,21 +17,33 @@ from ezdxf.addons import geo
 from ezdxf.render.forms import square, translate
 
 EXTERIOR = [(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)]
+EXTERIOR_Z = [(0, 0, 1), (10, 0, 1), (10, 10, 1), (0, 10, 1), (0, 0, 1)]
 HOLE1 = [(1, 1), (1, 2), (2, 2), (2, 1), (1, 1)]
 HOLE2 = [(3, 3), (3, 4), (4, 4), (4, 3), (3, 3)]
 
 POINT = {"type": "Point", "coordinates": (0, 0)}
+POINT_Z = {"type": "Point", "coordinates": (0, 0, 1)}
 LINE_STRING = {"type": "LineString", "coordinates": EXTERIOR}
+LINE_STRING_Z = {"type": "LineString", "coordinates": EXTERIOR_Z}
 POLYGON_0 = {"type": "Polygon", "coordinates": [EXTERIOR]}
+POLYGON_0_Z = {"type": "Polygon", "coordinates": [EXTERIOR_Z]}
 POLYGON_1 = {"type": "Polygon", "coordinates": [EXTERIOR, HOLE1]}
 POLYGON_2 = {"type": "Polygon", "coordinates": [EXTERIOR, HOLE1, HOLE2]}
 MULTI_POINT = {
     "type": "MultiPoint",
     "coordinates": EXTERIOR,
 }
+MULTI_POINT_Z = {
+    "type": "MultiPoint",
+    "coordinates": EXTERIOR_Z,
+}
 MULTI_LINE_STRING = {
     "type": "MultiLineString",
     "coordinates": [EXTERIOR, HOLE1, HOLE2],
+}
+MULTI_LINE_STRING_Z = {
+    "type": "MultiLineString",
+    "coordinates": [EXTERIOR_Z],
 }
 MULTI_POLYGON = {
     "type": "MultiPolygon",
@@ -40,6 +52,10 @@ MULTI_POLYGON = {
         [EXTERIOR, HOLE1],
         [EXTERIOR, HOLE1, HOLE2],
     ],
+}
+MULTI_POLYGON_Z = {
+    "type": "MultiPolygon",
+    "coordinates": [[EXTERIOR_Z]],
 }
 
 GEOMETRY_COLLECTION = {
@@ -280,16 +296,22 @@ def test_iter_feature_with_geometry_collection():
     "entity",
     [
         POINT,
+        POINT_Z,
         LINE_STRING,
+        LINE_STRING_Z,
         POLYGON_0,
+        POLYGON_0_Z,
         POLYGON_1,
         POLYGON_2,
         GEOMETRY_COLLECTION,
         FEATURE_1,
         FEATURE_COLLECTION,
         MULTI_POINT,
+        MULTI_POINT_Z,
         MULTI_LINE_STRING,
+        MULTI_LINE_STRING_Z,
         MULTI_POLYGON,
+        MULTI_POLYGON_Z,
     ],
 )
 def test_geo_interface_builder(entity):


### PR DESCRIPTION
## Description

This pull request adds support for exporting the `z` component of the geometries when calling the `__geo_interface__` method of the `GeoProxy` object.

If the entity contains at least one non-zero `z` component, it is interpreted as a 3D object, and the coordinates will be exported as `tuple[float, float, float]`.