### PR TITLE
Make transformation matrix accessible on the SVGBackend

### DIFF
--- a/src/ezdxf/addons/drawing/svg.py
+++ b/src/ezdxf/addons/drawing/svg.py
@@ -29,6 +29,7 @@ class SVGBackend(recorder.Recorder):
     def __init__(self) -> None:
         super().__init__()
         self._init_flip_y = True
+        self.transformation_matrix: Matrix44 | None = None
 
     def get_xml_root_element(
         self,
@@ -51,11 +52,11 @@ class SVGBackend(recorder.Recorder):
         if page.width == 0 or page.height == 0:
             return ET.Element("svg")  # empty page
 
-        m = output_layout.get_placement_matrix(
+        self.transformation_matrix = output_layout.get_placement_matrix(
             page, settings=settings, top_origin=top_origin
         )
         # transform content to the output coordinates space:
-        player.transform(m)
+        player.transform(self.transformation_matrix)
         if settings.crop_at_margins:
             p1, p2 = page.get_margin_rect(top_origin=top_origin)  # in mm
             # scale factor to map page coordinates to output space coordinates:


### PR DESCRIPTION
When using the matplotlib backend, it is possible to easily convert coordinates in the DXF space to the output space: https://ezdxf.readthedocs.io/en/stable/howto/drawing-addon.html#how-to-get-the-pixel-coordinates-of-dxf-entities

This pull request saves the transformation matrix in an object variable on the `SVGBackend` to provide a similar functionality for this backend as well. 
Short example: `vector_in_svg_space = backend.transformation_matrix.transform(vector_in_dxf_space)`

I've been using this modification for a while and thought maybe it would be useful for others as well.