### PR TITLE
fix: stable arrow render in mlead when proxy is ignored

### DIFF
--- a/src/ezdxf/render/mleader.py
+++ b/src/ezdxf/render/mleader.py
@@ -642,22 +642,35 @@ class RenderEngine:
         if len(vertices) < 2:  # at least 2 vertices required
             return
 
-        arrow_direction: Vec3 = get_arrow_direction(vertices)
+        delta: Vec3 = vertices[1] - vertices[0]
+        dist: float = delta.magnitude
+        arrow_direction: Vec3 = X_AXIS
+
+        # can be a lead with zero length
+        if dist > 0.0:
+            arrow_direction = delta.normalize()
+
         raw_color: int = line.color
-        index: int = line.index
-        block_name: str = self.create_arrow_block(self.arrow_block_name(index))
         arrow_size: float = self.context.arrow_head_size
-        self.add_arrow(
-            name=block_name,
-            location=vertices[0],
-            direction=arrow_direction,
-            scale=arrow_size,
-            color=raw_color,
-        )
-        arrow_offset: Vec3 = arrow_direction * arrow_length(
-            block_name, arrow_size
-        )
-        vertices[0] += arrow_offset
+
+        # nanocad/autocad no render mlead arrow when
+        # last dist less that 2 size of arrow
+        # also must check on zero size and dist
+        if dist * arrow_size > .0 and dist > arrow_size * 2.0:
+            index: int = line.index
+            block_name: str = self.create_arrow_block(self.arrow_block_name(index))
+            self.add_arrow(
+                name=block_name,
+                location=vertices[0],
+                direction=arrow_direction,
+                scale=arrow_size,
+                color=raw_color,
+            )
+            arrow_offset: Vec3 = arrow_direction * arrow_length(
+                block_name, arrow_size
+            )
+            vertices[0] += arrow_offset
+
         if leader_type == 1:  # add straight lines
             for s, e in zip(vertices, vertices[1:]):
                 self.add_dxf_line(s, e, raw_color)


### PR DESCRIPTION
For some reason we can't use a PROXY ( see #1241 ) on MLEADER entity and should use implementation from lib, whics not fully correctly render ( or crash at all ) leaders.

1. Leader cam have a zero-line length and we got a ZeroDivisionCrash when try render arrow
```log
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/addons/drawing/frontend.py", line 299, in draw_layout
    self.draw_entities(
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/addons/drawing/frontend.py", line 342, in draw_entities
    _draw_entities(self, self.ctx, entities, filter_func=filter_func)
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/addons/drawing/frontend.py", line 1046, in _draw_entities
    frontend.draw_entity(entity, properties)
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/addons/drawing/frontend.py", line 387, in draw_entity
    self.draw_composite_entity(entity, properties)
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/addons/drawing/frontend.py", line 937, in draw_composite_entity
    self.draw_entities(virtual_entities(entity))
                       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/protocols.py", line 48, in virtual_entities
    return entity.__virtual_entities__()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/entities/mleader.py", line 607, in __virtual_entities__
    return mleader.virtual_entities(self, proxy_graphic=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/render/mleader.py", line 175, in virtual_entities
    return iter(RenderEngine(mleader, doc).run())
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/render/mleader.py", line 419, in run
    self.add_leaders()
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/render/mleader.py", line 538, in add_leaders
    self.add_leader_line(leader, line)
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/render/mleader.py", line 645, in add_leader_line
    arrow_direction: Vec3 = get_arrow_direction(vertices)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/exponenta/projects/ezdxf/src/ezdxf/render/mleader.py", line 207, in get_arrow_direction
    return direction.normalize()
           ^^^^^^^^^^^^^^^^^^^^^
  File "src/ezdxf/acc/vector.pyx", line 581, in ezdxf.acc.vector.Vec3.normalize
  File "src/ezdxf/acc/vector.pyx", line 790, in ezdxf.acc.vector.v3_normalize
ZeroDivisionError: float division
```

2. Leader can have a ending line length less than arrow and we render a HUGE line instead skip it

**Source:**
[mlead_crash.dxf.zip](https://github.com/user-attachments/files/24061899/mlead_crash.dxf.zip)

( i can't remove proxy from DXFs in CAD application, follow #1241 for check )


**Before**:
( i bypassed zero-division for render the last leader, otherwise ) :
<img width="360" height="285" alt="Снимок экрана 2025-12-09 в 21 43 25" src="https://github.com/user-attachments/assets/cac33c8d-92c8-442a-905f-0984cbdde343" />

**After**:
<img width="360" height="180" alt="Снимок экрана 2025-12-09 в 21 48 28" src="https://github.com/user-attachments/assets/91323a75-06bc-4b27-8b61-f16942414f8b" />

**Reference**:
**PROXY ( view )**
<img width="360" height="225" alt="Снимок экрана 2025-12-09 в 21 49 37" src="https://github.com/user-attachments/assets/7c16f706-1976-46b8-991c-0f4dc1903006" />

**ACAD**

<img width="369" height="250" alt="Screenshot_5" src="https://github.com/user-attachments/assets/ef46ca62-981e-48c4-98c2-f11551324b20" />
