### PR TITLE
Fix bug 1368: Layer linetype patterns are empty when using custom lay…

### DIFF
--- a/src/ezdxf/addons/drawing/properties.py
+++ b/src/ezdxf/addons/drawing/properties.py
@@ -350,8 +350,8 @@ class RenderContext:
         self._layer_properties_override: Optional[LayerPropsOverride] = None
 
         if doc:
-            self.set_current_layout(doc.modelspace())
             self.line_pattern = _load_line_pattern(doc.linetypes)
+            self.set_current_layout(doc.modelspace())
             self.linetype_scale = doc.header.get("$LTSCALE", 1.0)
             self.pdsize = doc.header.get("$PDSIZE", 1.0)
             self.pdmode = doc.header.get("$PDMODE", 0)

--- a/tests/test_08_addons/test_810_drawing_properties.py
+++ b/tests/test_08_addons/test_810_drawing_properties.py
@@ -362,5 +362,21 @@ def test_resolve_transparency_from_layer():
     assert prop.color == "#0000ff7f"
 
 
+def test_bylayer_linetype_properties():
+    doc = ezdxf.new()
+    doc.linetypes.add(
+        name="CUSTOM_DASH",
+        pattern=[1, 12.0, -3.0],
+    )
+    doc.layers.add("CustomLayer", linetype="CUSTOM_DASH")
+    msp = doc.modelspace()
+    line = msp.add_line((0, 1), (1, 0), dxfattribs={"layer": "CustomLayer"})
+    ctx = RenderContext(doc)
+    properties = ctx.resolve_all(line)
+
+    assert properties.linetype_name == "CUSTOM_DASH"
+    assert properties.linetype_pattern == (12.0, 3.0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
**Bug description**

When rendering a DXF document with the drawing addon's Frontend class and passing a custom layout properties parameter to the draw_layout method, entities with linetype set to "BYLAYER" (or no explicit linetype attribute, which defaults to "BYLAYER") are rendered as solid lines instead of using their layer's linetype pattern (dashes, dots, etc.).

This happens because of an initialization order bug in the RenderContext class:

During RenderContext initialization, the method that sets up the current layout is called before the line patterns are loaded from the document's linetype table
When layers are initialized and their properties are resolved, the line pattern dictionary is still empty, so all layers get cached with an empty continuous pattern (empty tuple)
When Frontend's draw_layout method receives a custom layout properties parameter, it skips calling the layout setup method again (which would re-cache the layers with correct patterns)
Entities that use BYLAYER linetype resolution inherit the empty patterns from the cached layer properties
The bug does NOT occur when:

The layout properties parameter is NOT passed to draw_layout (Frontend calls the layout setup method again, re-caching layers with correct patterns after line patterns are loaded)
Entities have explicit linetype attributes set directly (bypasses BYLAYER resolution and looks up patterns directly)

**Fix**

Call `_load_line_pattern` before `self.set_current_layout` in the `__init__` of `RenderContext`.
Added a unit test and verified the other tests passed.