### PR TITLE
docs: clarify LWPolyline.transform extrusion-flip behavior

### DIFF
--- a/src/ezdxf/entities/lwpolyline.py
+++ b/src/ezdxf/entities/lwpolyline.py
@@ -356,6 +356,19 @@ class LWPolyline(DXFGraphic):
         A non-uniform scaling is not supported if the entity contains circular
         arc segments (bulges).
 
+        .. note::
+
+            LWPOLYLINE stores points in the :ref:`OCS` defined by
+            :attr:`dxf.extrusion`. For transforms that include a reflection
+            (e.g. a matrix derived from an INSERT with a negative scale
+            factor), :attr:`dxf.extrusion` flips sign to preserve the
+            geometry — the stored points themselves are not mirrored in
+            place. Methods that read raw storage (:meth:`get_points`,
+            :meth:`vertices`, :meth:`__getitem__`) therefore continue to
+            return OCS coordinates relative to the new extrusion, which
+            may differ from WCS. Use :meth:`vertices_in_wcs` when you
+            need world coordinates after a transform.
+
         Args:
             m: transformation :class:`~ezdxf.math.Matrix44`
 


### PR DESCRIPTION
## Summary

Add a `.. note::` to `LWPolyline.transform()` explaining that a transform containing a reflection flips `dxf.extrusion` rather than mirroring the stored points in place. Methods that read raw storage (`get_points`, `vertices`, `__getitem__`) therefore continue to return OCS coordinates relative to the new extrusion, which may differ from WCS. Point callers at `vertices_in_wcs()` for world coordinates after a transform.

Pure documentation change — no behavior change.

## Motivation

This is a subtle OCS footgun that trips up users who flatten block references via `virtual_entities()`. An INSERT with `xscale=-1` (a common way to represent a horizontal mirror in DXF) expands to an LWPOLYLINE whose stored x-coordinates are unchanged but whose extrusion has flipped from `(0,0,1)` to `(0,0,-1)`. The geometry is correct when interpreted through OCS, but any consumer reading `get_points(format="xy")` and treating them as WCS silently sees coordinates mirrored about x=0.

## Repro

```python
import ezdxf
doc = ezdxf.new("R2018")
inner = doc.blocks.new("INNER")
inner.add_lwpolyline([(0, 0), (10, 0), (10, 5), (0, 5)], close=True)
outer = doc.blocks.new("OUTER")
outer.add_blockref("INNER", (0, 0))
doc.modelspace().add_blockref("OUTER", (-100, 0), dxfattribs={"xscale": -1})

ref = next(e for e in doc.modelspace() if e.dxftype() == "INSERT")
for child in ref.virtual_entities():
    if child.dxftype() == "INSERT":
        for p in child.virtual_entities():
            if p.dxftype() == "LWPOLYLINE":
                print("extrusion:", tuple(p.dxf.extrusion))
                print("get_points:", list(p.get_points(format="xy")))
                print("vertices_in_wcs:", [tuple(v.xyz) for v in p.vertices_in_wcs()])
```

Output:
```
extrusion: (0.0, 0.0, -1.0)
get_points: [(100.0, 0.0), (110.0, 0.0), (110.0, 5.0), (100.0, 5.0)]
vertices_in_wcs: [(-100.0, 0.0, 0.0), (-110.0, 0.0, 0.0), (-110.0, 5.0, 0.0), (-100.0, 5.0, 0.0)]
```

The individual point-access methods (`__getitem__`, `vertices`, `append`, `insert`, `append_points`) already document "All coordinates in OCS", but `transform()` doesn't warn that extrusion may flip — which is when the OCS ≠ WCS case becomes load-bearing. This PR adds that note and cross-links to `vertices_in_wcs()`.

## Test plan

- [x] `pytest tests/test_02_dxf_graphics/test_220_lwpolyline_*.py` passes (30/30)
- [x] Pure docstring addition, no runtime code changed