### PR TITLE
feat: add content_hash property to DXFEntity

### DIFF
--- a/src/ezdxf/entities/dxfentity.py
+++ b/src/ezdxf/entities/dxfentity.py
@@ -27,6 +27,7 @@ from typing import (
 )
 from typing_extensions import Self
 
+import hashlib
 import logging
 import uuid
 from ezdxf import options
@@ -131,6 +132,28 @@ class DXFEntity:
             uuid_ = uuid.uuid4()
             setattr(self, DYN_UUID_ATTRIBUTE, uuid_)
         return uuid_
+
+    @property
+    def content_hash(self) -> str:
+        """Returns a SHA-256 hash derived from the entity's DXF content.
+
+        Two entities with identical DXF properties will produce the same hash,
+        regardless of handle, owner, or Python object identity.  This is useful
+        for detecting duplicates or tracking content changes.
+
+        The hash is computed on demand and NOT cached, because any attribute
+        mutation would silently invalidate a cached value.
+        """
+        from io import StringIO
+        from ezdxf.lldxf.tagwriter import TagWriter
+        from ezdxf.lldxf.const import DXF2013
+
+        stream = StringIO()
+        tagwriter = TagWriter(stream, dxfversion=DXF2013, write_handles=False)
+        tagwriter.force_optional = True
+        self.export_entity(tagwriter)
+        self.export_xdata(tagwriter)
+        return hashlib.sha256(stream.getvalue().encode("utf-8")).hexdigest()
 
     @classmethod
     def new(

--- a/tests/test_01_dxf_entities/test_110_dxfentity.py
+++ b/tests/test_01_dxf_entities/test_110_dxfentity.py
@@ -467,3 +467,58 @@ class TestGetLayout:
         circle = msp.add_circle(center=(0, 0), radius=1)
         msp.unlink_entity(circle)
         assert circle.get_layout() is None
+
+
+class TestContentHash:
+    def test_content_hash_returns_hex_string(self):
+        line = Line.new(dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        h = line.content_hash
+        assert isinstance(h, str)
+        assert len(h) == 64  # SHA-256 hex digest
+
+    def test_identical_entities_same_hash(self):
+        line1 = Line.new(dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        line2 = Line.new(dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        assert line1.content_hash == line2.content_hash
+
+    def test_different_entities_different_hash(self):
+        line1 = Line.new(dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        line2 = Line.new(dxfattribs={"start": (0, 0, 0), "end": (2, 2, 2)})
+        assert line1.content_hash != line2.content_hash
+
+    def test_hash_ignores_handle(self):
+        line1 = Line.new(handle="AAA", dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        line2 = Line.new(handle="BBB", dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        assert line1.content_hash == line2.content_hash
+
+    def test_hash_ignores_owner(self):
+        line1 = Line.new(owner="AAA", dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        line2 = Line.new(owner="BBB", dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        assert line1.content_hash == line2.content_hash
+
+    def test_hash_changes_on_mutation(self):
+        line = Line.new(dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        h1 = line.content_hash
+        line.dxf.end = (5, 5, 5)
+        h2 = line.content_hash
+        assert h1 != h2
+
+    def test_different_layers_produce_different_hash(self):
+        line1 = Line.new(dxfattribs={"layer": "A", "start": (0, 0, 0), "end": (1, 1, 1)})
+        line2 = Line.new(dxfattribs={"layer": "B", "start": (0, 0, 0), "end": (1, 1, 1)})
+        assert line1.content_hash != line2.content_hash
+
+    def test_copy_has_same_hash(self):
+        line = Line.new(dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        clone = line.copy()
+        assert line.content_hash == clone.content_hash
+
+    def test_hash_is_deterministic(self):
+        line = Line.new(dxfattribs={"start": (0, 0, 0), "end": (1, 1, 1)})
+        assert line.content_hash == line.content_hash
+
+    def test_base_entity_content_hash(self):
+        e = DXFEntity()
+        h = e.content_hash
+        assert isinstance(h, str)
+        assert len(h) == 64


### PR DESCRIPTION
## Summary

- Adds a `content_hash` property to `DXFEntity` that returns a deterministic SHA-256 hex digest derived from the entity's DXF content (entity-specific attributes + xdata).
- The hash is **identity-agnostic**: handle, owner, and Python object identity are excluded, so two entities with identical DXF properties produce the same hash.
- Useful for **duplicate detection**, **content change tracking**, and **diffing** DXF documents.

## Implementation

The property serializes entity content via the existing `export_entity()` and `export_xdata()` methods into a `TagWriter` with `write_handles=False`, then hashes the resulting string with SHA-256. This leverages the same serialization path used for DXF file export, so it captures all entity data including complex sub-structures (LWPOLYLINE vertices, HATCH paths, SPLINE control points, MTEXT text content, etc.).

The hash is computed on demand and **not cached**, because any attribute mutation would silently invalidate a cached value.

### Example usage

```python
import ezdxf

doc = ezdxf.readfile("drawing.dxf")
msp = doc.modelspace()

seen = set()
for entity in msp:
    h = entity.content_hash
    if h in seen:
        print(f"Duplicate: {entity}")
    seen.add(h)
```

## Test plan

- [x] `content_hash` returns a 64-character hex string (SHA-256)
- [x] Entities with identical properties produce the same hash
- [x] Entities with different properties produce different hashes
- [x] Hash ignores handle differences
- [x] Hash ignores owner differences
- [x] Hash changes when entity attributes are mutated
- [x] Different layers produce different hashes
- [x] A copy produces the same hash as the original
- [x] Hash is deterministic (same result on repeated calls)
- [x] Works on base `DXFEntity` class (not just subclasses)


Made with [Cursor](https://cursor.com)