### PR TITLE
Fix calendardate()/juliandate() round-trip losing one second

### DIFF
--- a/src/ezdxf/tools/juliandate.py
+++ b/src/ezdxf/tools/juliandate.py
@@ -55,7 +55,14 @@ class CalendarDate:
 
 
 def frac2time(jdate) -> tuple[int, int, int]:
-    seconds = int(frac(jdate) * 86400.0)
+    # The Julian day number is large, so frac(jdate) loses precision and
+    # int() would truncate e.g. 47720.99998 down to 47720, dropping a second
+    # on the juliandate()/calendardate() round-trip. Round to the nearest
+    # second instead, guarding against a near-midnight value rounding up to
+    # 86400 (which would make hour == 24 and raise ValueError).
+    seconds = round(frac(jdate) * 86400.0)
+    if seconds >= 86400:
+        seconds = 86399
     hour = int(seconds / 3600)
     seconds = seconds % 3600
     minute = int(seconds / 60)

--- a/tests/test_00_dxf_low_level_structs/test_013_juliandate.py
+++ b/tests/test_00_dxf_low_level_structs/test_013_juliandate.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2011-2019, Manfred Moitzi
 # License: MIT License
 import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from ezdxf.tools.juliandate import juliandate, calendardate
 
@@ -36,3 +36,33 @@ class TestCalendarDate:
     def test_2011_03_21(self):
         check = datetime(2011, 3, 21, 18, 0, 0)
         assert calendardate(2455642.75) == check
+
+
+class TestRoundTrip:
+    # juliandate() and calendardate() are inverses (used to write/read the
+    # $TDCREATE/$TDUPDATE header vars). The round-trip must not lose a second;
+    # frac2time() previously truncated frac(jdate) * 86400 with int(), so float
+    # imprecision dropped one second on ~50% of timestamps.
+    @pytest.mark.parametrize("date", [
+        datetime(2020, 1, 1, 0, 0, 1),
+        datetime(2030, 2, 28, 6, 15, 7),
+        datetime(1999, 12, 31, 23, 59, 59),
+        datetime(2000, 2, 29, 12, 0, 0),
+        datetime(2011, 3, 21, 18, 0, 0),
+        datetime(1990, 1, 1, 0, 0, 0),
+    ])
+    def test_roundtrip_preserves_seconds(self, date):
+        assert calendardate(juliandate(date)) == date
+
+    def test_roundtrip_sweep_loses_nothing(self):
+        # Every second over several days must survive the round-trip exactly.
+        start = datetime(2020, 6, 1, 0, 0, 0)
+        for i in range(0, 200000, 7):
+            date = start + timedelta(seconds=i)
+            assert calendardate(juliandate(date)) == date
+
+    def test_near_midnight_does_not_overflow(self):
+        # A fraction that rounds up toward a full day must clamp to 23:59:59
+        # rather than yielding hour == 24 (which would raise ValueError).
+        result = calendardate(2451545.0 + 0.99999999)
+        assert (result.hour, result.minute, result.second) == (23, 59, 59)


### PR DESCRIPTION
### The bug

`calendardate()` and `juliandate()` are documented inverses (they read/write the `$TDCREATE`/`$TDUPDATE` drawing timestamps), but the round-trip silently loses one second on ~50% of timestamps:

```python
>>> from datetime import datetime
>>> from ezdxf.tools.juliandate import juliandate, calendardate
>>> calendardate(juliandate(datetime(2020, 1, 1, 0, 0, 1)))
datetime.datetime(2020, 1, 1, 0, 0, 0)        # lost a second (expected 00:00:01)
>>> calendardate(juliandate(datetime(2030, 2, 28, 6, 15, 7)))
datetime.datetime(2030, 2, 28, 6, 15, 6)
```

A sweep of 500,000 timestamps loses exactly one second on **249,448 (49.9%)** of them.

### Why the expected result is unambiguous

The two functions are inverses by design (the test module has paired `TestJulianDate`/`TestCalendarDate` classes), and the value is a real drawing timestamp that must survive a write→read cycle. The existing `TestCalendarDate.test_1999_12_31` is itself a tell: it asserts `calendardate(2451544.91568288)` while `TestJulianDate.test_1999_12_31` computes `2451544.9156828`**`7`** for the same datetime — the last digit was hand-bumped to dodge the off-by-one, and the composed round-trip was never tested.

### Root cause

`src/ezdxf/tools/juliandate.py`, `frac2time`:

```python
seconds = int(frac(jdate) * 86400.0)
```

The Julian day number is large (~2.45e6), so adding the fractional day and re-extracting `frac()` introduces a tiny negative float error: `frac(jdate) * 86400` lands just below the stored integer second (e.g. `47720.99998` instead of `47721`), and `int()` truncates toward zero, dropping the second.

### The fix

Round to the nearest second instead of truncating, with a guard so a near-midnight fraction can't round up to `86400` (which would make `hour == 24` and raise `ValueError` — an edge `int()` couldn't reach):

```python
seconds = round(frac(jdate) * 86400.0)
if seconds >= 86400:
    seconds = 86399
```

With this, all 500,000 sampled timestamps round-trip exactly, and the near-midnight case clamps to `23:59:59` instead of crashing.

### Tests

A new `TestRoundTrip` class in `test_013_juliandate.py`: six parametrized `calendardate(juliandate(d)) == d` cases (including `00:00:01`, the day boundary `23:59:59`, and a leap day), a per-second sweep across several days asserting zero loss, and the near-midnight no-overflow guard. The off-by-one cases and the sweep fail on `master` and pass with the fix; the existing `juliandate`/`calendardate` and drawing-object (`$TDCREATE`) tests stay green.

(Out of scope: `get_date()` is separately off by a couple of days for year-1 dates — pre-existing and unrelated to this fix.)
