### PR TITLE
fix: numerically robust ConstructionRay.intersect fixes aligned-dimension rendering for near-vertical segments

### DIFF
--- a/src/ezdxf/math/line.py
+++ b/src/ezdxf/math/line.py
@@ -151,11 +151,17 @@ class ConstructionRay:
             y = ray2._location.y
             x = ray1.xof(y)
         else:
-            # calc intersection with the 'straight-line-equation'
-            # based on y(x) = y0 + x*slope
-            # guards above guarantee that no slope is None
-            x = (ray1._yof0 - ray2._yof0) / (ray2._slope - ray1._slope)  # type: ignore
-            y = ray1.yof(x)
+            # Parametric intersection relative to ray1._location. Computing the
+            # hit point relative to a nearby location (instead of the slope /
+            # y-intercept form based on x=0) avoids catastrophic cancellation
+            # for near-axis-aligned rays with large coordinates.
+            # The is_parallel() guard above guarantees denom != 0 here.
+            o = ray2._location - ray1._location
+            d1 = ray1._direction
+            d2 = ray2._direction
+            denom = d1.x * d2.y - d1.y * d2.x
+            t = (o.x * d2.y - o.y * d2.x) / denom
+            x, y = ray1._location + d1 * t
         return Vec2((x, y))
 
     def orthogonal(self, location: UVec) -> ConstructionRay:

--- a/tests/test_06_math/test_641_construction_ray.py
+++ b/tests/test_06_math/test_641_construction_ray.py
@@ -121,6 +121,26 @@ class TestConstructionRay:
         with pytest.raises(ParallelRaysError):
             _ = ray1.bisectrix(ray3)
 
+    def test_near_vertical_ray_large_coordinates(self):
+        # Regression test for issue #1300: a near-vertical ray with large
+        # coordinates (as produced by aligned dimensions) must intersect its
+        # orthogonal rays accurately. The old slope / y-intercept formula in
+        # intersect() suffered catastrophic cancellation here and returned a
+        # wrong span (32 instead of 44).
+        p0 = (250235.337, 99368)
+        p1 = (250235.337, 99412)
+        # angle of (p1 - p0) is 89.99999999984841 deg -> near vertical but the
+        # tiny direction.x keeps the ray on the general (slope-based) path.
+        ray = ConstructionRay(p0, angle=89.99999999984841 / 180.0 * math.pi)
+        assert ray._is_vertical is False
+        assert ray._is_horizontal is False
+
+        hit0 = ray.intersect(ray.orthogonal(p0))
+        hit1 = ray.intersect(ray.orthogonal(p1))
+        assert math.isclose(hit0.y, 99368, abs_tol=1e-6)
+        assert math.isclose(hit1.y, 99412, abs_tol=1e-6)
+        assert math.isclose(hit1.y - hit0.y, 44, abs_tol=1e-6)
+
     def test_two_close_horizontal_rays(self):
         p1 = (39340.75302672016, 32489.73349764998)
         p2 = (39037.75302672119, 32489.73349764978)

--- a/tests/test_07_render/test_704_render_linear_dimension.py
+++ b/tests/test_07_render/test_704_render_linear_dimension.py
@@ -111,6 +111,26 @@ def test_dimension_insert_attribute_translates_the_block_content():
         assert (vpoint.dxf.location - blk_point.dxf.location).isclose(INSERT)
 
 
+def test_aligned_dim_near_vertical_measurement():
+    # Regression test for issue #1300: an aligned dimension whose points are
+    # only slightly non-vertical (a tiny x-difference) rendered a wrong
+    # measurement (32 instead of 44) because ConstructionRay.intersect lost
+    # precision on the near-vertical dimension-line ray.
+    doc = ezdxf.new()
+    msp = doc.modelspace()
+    dim = msp.add_aligned_dim(
+        p1=(250235.3373553778, 99368),
+        p2=(250235.3373553779, 99412),
+        distance=20,
+    )
+    dim.render()
+    dimension = dim.dimension
+    blk = dimension.get_geometry_block()
+    mtext = [e for e in blk if e.dxftype() == "MTEXT"][0]
+    assert mtext.text == "44"
+    assert float(mtext.text) == dimension.get_measurement()
+
+
 @pytest.mark.parametrize("color", [1, 7])
 def test_override_all_colors(color):
     new_doc = ezdxf.new()


### PR DESCRIPTION
## Summary

Aligned dimensions whose two points are only slightly non-vertical (a tiny x-difference) now render the correct measurement and extension-line geometry instead of losing precision. `ConstructionRay.intersect` now computes the general-case intersection with a parametric determinant relative to the ray location rather than the slope / y-intercept form.

## Why this matters

Reported in #1300: `add_aligned_dim((250235.3373553778, 99368), (250235.3373553779, 99412), distance=20).render()` draws a measurement of `32` even though `dimension.get_measurement()` correctly returns `44`.

The dimension-line ray for an aligned dimension is near vertical, so `direction.x` is about `2.6e-12`, just above `ABS_TOL`, and the ray is treated as non-vertical with a slope near `3.78e11`. The general branch of `ConstructionRay.intersect` then solved `x = (ray1._yof0 - ray2._yof0) / (ray2._slope - ray1._slope)`, where `_yof0` is the y value at `x=0`, far from the actual coordinates (`x` around `250235`) and amplified by the huge slope. The result is catastrophic cancellation: the extension-ray intersections land at `99376` and `99408` (span `32`) instead of `99368` and `99412` (span `44`), which is exactly the value the renderer draws.

The fix replaces that computation with a parametric intersection expressed relative to `ray1._location`: with `o = ray2._location - ray1._location`, `denom = d1.x*d2.y - d1.y*d2.x`, the hit point is `ray1._location + d1 * ((o.x*d2.y - o.y*d2.x)/denom)`. Because everything is computed relative to a nearby location instead of `x=0`, there is no slope amplification and the result stays accurate for large coordinates and near-axis-aligned rays. The exact vertical/horizontal short-circuit branches and the `is_parallel` guard are unchanged (the guard ensures `denom` is non-zero here), and `_slope`, `_yof0`, `yof`, and `xof` are untouched, so this is a strict accuracy improvement with no API change.

## Testing

- Added a regression test in `test_641_construction_ray.py` that intersects a near-vertical ray at large coordinates with its orthogonal rays and asserts the span is `44`; it fails on the old slope/intercept code and passes with the fix.
- Added a symptom-level regression test in `test_704_render_linear_dimension.py` that builds the reporter's aligned dimension and asserts the rendered MTEXT measurement equals `44` and matches `get_measurement()`.
- `pytest tests/test_06_math tests/test_07_render` passes (2795 passed, 2 skipped, 1 xfailed); `mypy --ignore-missing-imports` on the changed module reports no issues.

Fixes #1300
