### PR TITLE
Fix #1402: translate hatch pattern base points in DXFPolygon.transform()

### DIFF
--- a/src/ezdxf/entities/polygon.py
+++ b/src/ezdxf/entities/polygon.py
@@ -408,7 +408,24 @@ class DXFPolygon(DXFGraphic):
 
             # rotation relative to current state:
             rotation_angle = ocs.transform_deg_angle(0)
+
+            # Capture the original base points before scaling/rotating the
+            # pattern. Pattern.scale() applies only the linear part (scale and
+            # rotation) of the transformation to the base points, it never
+            # translates them, so the pattern phase drifts relative to the
+            # boundary under any translation (issue #1402).
+            original_base_points = [line.base_point for line in self.pattern.lines]
             self.pattern.scale(relative_factor, rotation_angle)
+
+            # Translate the base points by mapping each original base point once
+            # with the full transformation, exactly like a boundary path vertex
+            # (see PolylinePath.transform). Mapping the original point with the
+            # full affine transform avoids double-applying the linear part that
+            # Pattern.scale() already handled.
+            for line, base_point in zip(self.pattern.lines, original_base_points):
+                line.base_point = ocs.transform_vertex(
+                    Vec3(base_point.x, base_point.y, elevation)
+                ).vec2
 
             # The pattern_scale factor has to be applied to the base pattern to get the
             # final scaling. This is important for CAD applications, not for the rendering

--- a/tests/test_02_dxf_graphics/test_229c_hatch_transformations.py
+++ b/tests/test_02_dxf_graphics/test_229c_hatch_transformations.py
@@ -239,3 +239,62 @@ def test_translation_does_not_change_pattern_line_angle():
 
     hatch.transform(Matrix44.translate(100, 0, 0))
     assert hatch.pattern.lines[0].angle == pytest.approx(pattern_line_angle)
+
+
+def test_translation_moves_pattern_base_point_like_a_boundary_vertex():
+    # Regression test for issue #1402: DXFPolygon.transform() translated the
+    # boundary paths but left the hatch pattern line base points untouched, so
+    # the pattern phase drifted relative to the boundary under any translation.
+    hatch = Hatch()
+    path = hatch.paths.add_polyline_path([(0, 0), (10, 0), (10, 10), (0, 10)])
+    hatch.set_pattern_fill("ANSI31", scale=1.0)
+    # anchor the first pattern line base point at the boundary origin (0, 0)
+    hatch.pattern.lines[0].base_point = Vec2(0, 0)
+
+    offset = Vec2(37.5, 11.0)
+    hatch.transform(Matrix44.translate(offset.x, offset.y, 0))
+
+    # the boundary vertex (0, 0) maps to the translation offset ...
+    vx, vy, _ = path.vertices[0]
+    assert Vec2(vx, vy).isclose(offset)
+    # ... and the pattern base point must move by the same translation
+    assert hatch.pattern.lines[0].base_point.isclose(offset)
+
+
+def test_translation_moves_every_pattern_base_point_by_the_same_offset():
+    # Regression test for issue #1402: every non-zero base point must move by
+    # the same translation as the boundary, keeping the pattern phase locked.
+    hatch = Hatch()
+    hatch.paths.add_polyline_path([(0, 0), (10, 0), (10, 10), (0, 10)])
+    hatch.set_pattern_fill("ANSI31", scale=1.0)
+    # give each pattern line a distinct non-zero base point
+    for index, line in enumerate(hatch.pattern.lines):
+        line.base_point = Vec2(index + 1, 2 * (index + 1))
+    original_base_points = [line.base_point for line in hatch.pattern.lines]
+
+    offset = Vec2(100, 25)
+    hatch.transform(Matrix44.translate(offset.x, offset.y, 0))
+
+    for line, base_point in zip(hatch.pattern.lines, original_base_points):
+        assert line.base_point.isclose(base_point + offset)
+
+
+def test_pattern_base_point_maps_like_boundary_vertex_under_full_transform():
+    # Regression test for issue #1402: a base point coincident with a boundary
+    # vertex must land on the exact same transformed point under a combined
+    # rotation + translation. This guards against double-applying the linear
+    # part that Pattern.scale() already handles.
+    vertices = [(2, 3), (10, 0), (10, 10), (0, 10)]
+    hatch = Hatch()
+    path = hatch.paths.add_polyline_path(vertices)
+    hatch.set_pattern_fill("ANSI31", scale=1.0)
+    hatch.pattern.lines[0].base_point = Vec2(2, 3)  # coincident with vertices[0]
+
+    m = Matrix44.chain(
+        Matrix44.z_rotate(math.radians(37)),
+        Matrix44.translate(37.5, 11.0, 0),
+    )
+    hatch.transform(m)
+
+    vx, vy, _ = path.vertices[0]
+    assert hatch.pattern.lines[0].base_point.isclose(Vec2(vx, vy))


### PR DESCRIPTION
## Repro (state-level)

Under any translating transform, `DXFPolygon.transform()` moves the HATCH/MPOLYGON boundary but leaves the pattern line `base_point` where it was, so the pattern phase drifts relative to the boundary:

```python
import ezdxf
from ezdxf.math import Matrix44, Vec2

hatch = ezdxf.new().modelspace().add_hatch()
hatch.paths.add_polyline_path([(0, 0), (10, 0), (10, 10), (0, 10)])
hatch.set_pattern_fill("ANSI31", scale=1.0)
hatch.pattern.lines[0].base_point = Vec2(0, 0)   # anchored on the boundary origin

hatch.transform(Matrix44.translate(37.5, 11.0, 0))

# boundary vertex (0,0) correctly moves to (37.5, 11.0)
# BUT hatch.pattern.lines[0].base_point stays at (0, 0)   <-- bug
```

## Cause

`transform()` applies the full affine transform to the boundary paths, but hands the pattern only the linear part (scale + rotation) via `self.pattern.scale(relative_factor, rotation_angle)`. `PatternLine.base_point` is a position, not a direction, so it also needs the translation -- which is never applied.

This completes the translation half of the sibling issue #1392: the rotation half was fixed in #1399 and the scaling half in #1391, but pattern base points were still never translated.

## Fix

Capture each line's original `base_point`, run `pattern.scale(...)` unchanged, then overwrite each base point by mapping the ORIGINAL point once through the same `OCSTransform` the boundary vertices use (`ocs.transform_vertex(Vec3(bp.x, bp.y, elevation))`). Mapping the original point with the full transform avoids double-applying the linear part that `scale()` already handled. Scaling and rotation behaviour is unchanged; only the missing translation of `base_point` is added.

## Tests

Added three state-level regression tests in `tests/test_02_dxf_graphics/test_229c_hatch_transformations.py`:

- pattern base point moves by the same translation as a boundary vertex (the repro above),
- every non-zero base point across all pattern lines moves by the same offset,
- a base point coincident with a boundary vertex lands on the exact same transformed point under a combined rotation + translation (guards against double-applying the linear part).

Red/green verified: the three tests fail on current `master` and pass with the fix; the full `-k "pattern or hatch"` suite is green with no regressions (195 passed, 3 skipped, C-extension built).

Fixes #1402. Thanks to @dwscat20 for the isolated, state-level reproduction.

---
This contribution was prepared with AI assistance and reviewed by me before submission.