### PR TITLE
Add literal percent sign conversion

### DIFF
--- a/src/ezdxf/lldxf/const.py
+++ b/src/ezdxf/lldxf/const.py
@@ -369,6 +369,7 @@ SPECIAL_CHAR_ENCODING = {
     "c": "Ø",  # alt-0216
     "d": "°",  # alt-0176
     "p": "±",  # alt-0177
+    "%": "%",  # literal percent sign (%%%)
 }
 # Inline codes for strokes in TEXT, ATTRIB and ATTDEF
 # %%u underline

--- a/tests/test_05_tools/test_514_text.py
+++ b/tests/test_05_tools/test_514_text.py
@@ -210,6 +210,7 @@ def test_plain_text():
     assert plain_text("%%C") == "Ø"  # alt-0216
     assert plain_text("%%D") == "°"  # alt-0176
     assert plain_text("%%P") == "±"  # alt-0177
+    assert plain_text("%%%") == "%"  # literal percent sign
     # underline
     assert plain_text("%%u") == ""
     assert plain_text("%%utext%%u") == "text"


### PR DESCRIPTION
Adds `%%%` to `SPECIAL_CHAR_ENCODING` so `plain_text()` resolves it to a
single literal percent sign, as documented by AutoCAD's control codes
reference:
https://help.autodesk.com/cloudhelp/2024/ENU/AutoCAD-Core/files/GUID-968CBC1D-BA99-4519-ABDD-88419EB2BF92.htm

Currently `%%c`, `%%d` and `%%p` are handled but `%%%` is left as three
characters, causing labels like `30%%%÷100%` to render as `30%%%÷100%`
instead of `30%÷100%`.

Also adds an assertion to the tests.